### PR TITLE
Namespace and Path Correction for TickerModelCustomizer

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
+++ b/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using TickerQ.EntityFrameworkCore.Configurations;
 using TickerQ.EntityFrameworkCore.Entities;
 
-namespace TickerQ.EntityFrameworkCore.Configurations
+namespace TickerQ.EntityFrameworkCore.Customizer
 {
     internal class TickerModelCustomizer<TTimeTicker, TCronTicker> : RelationalModelCustomizer
         where TTimeTicker : TimeTickerEntity where TCronTicker : CronTickerEntity

--- a/src/TickerQ.EntityFrameworkCore/DependencyInjection/ServiceExtension.cs
+++ b/src/TickerQ.EntityFrameworkCore/DependencyInjection/ServiceExtension.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
-using TickerQ.EntityFrameworkCore.Configurations;
+using TickerQ.EntityFrameworkCore.Customizer;
 using TickerQ.EntityFrameworkCore.Entities;
 using TickerQ.EntityFrameworkCore.Infrastructure;
 using TickerQ.Utilities;


### PR DESCRIPTION
## Overview
This PR fixes the namespace and file location for the `TickerModelCustomizer` component.

## Changes
* Moved `TickerModelCustomizer.cs` from `Costumizers` to `Customizer` directory
* Updated namespace from `TickerQ.EntityFrameworkCore.Configurations` to `TickerQ.EntityFrameworkCore.Customizer`
* Updated corresponding using statements in `TickerModelCustomizer` and `ServiceExtension.cs`

## Notes
* No functional changes were made - purely organizational improvement
* Resolves #65 
