### PR TITLE
Call `AddApplicationPart()` using the `TickerQController` assembly

### DIFF
--- a/src/TickerQ.Dashboard/DependencyInjection/NetTarget_v3_Higher.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/NetTarget_v3_Higher.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using TickerQ.Dashboard.Controllers;
 using TickerQ.Dashboard.Hubs;
 
 namespace TickerQ.Dashboard.DependencyInjection
@@ -25,7 +26,7 @@ namespace TickerQ.Dashboard.DependencyInjection
                         .AllowCredentials();
                 });
             });
-            services.AddControllers();
+            services.AddControllers().AddApplicationPart(typeof(TickerQController).Assembly);
         }
 
         internal static void UseDashboard(IApplicationBuilder app, string basePath)


### PR DESCRIPTION
On newer versions of dotnet, the api controller `TickerQController` was not being discovered when just calling `AddControllers()`.

By calling `AddApplicationPart()` with the assembly for `TickerQController`, the controller is able to be discovered.

See relevant discussion here: https://github.com/dotnet/aspnetcore/issues/13850