### PR TITLE
Add support for on demand cron ticker execution

### DIFF
--- a/src/TickerQ.Dashboard/Controllers/TickerQController.cs
+++ b/src/TickerQ.Dashboard/Controllers/TickerQController.cs
@@ -199,6 +199,13 @@ namespace TickerQ.Dashboard.Controllers
             await TickerDashboardRepository.UpdateCronTickerAsync(id, jsonString);
             return Ok();
         }
+        
+        [HttpPost("cron-ticker/:run")]
+        public async Task<IActionResult> RunCronTickerOnDemandAsync([FromQuery] Guid id)
+        {
+            await TickerDashboardRepository.AddOnDemandCronTickerOccurrenceAsync(id);
+            return Ok();
+        }
 
         [HttpGet("ticker-host/:next-ticker")]
         public IActionResult GetNextTickerAsync()

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
@@ -71,6 +71,16 @@ const deleteCronTicker = () => {
     };
 }
 
+const runCronTickerOnDemand = () => {
+    const baseHttp = useBaseHttpService<object, object>('single')
+    const requestAsync = async (id: string) => (await baseHttp.sendAsync("POST", "cron-ticker/:run", { paramData: { id } }));
+
+    return {
+        ...baseHttp,
+        requestAsync
+    };
+}
+
 const getTimeTickersGraphDataRange = () => {
     const baseHttp = useBaseHttpService<object, GetCronTickerGraphDataRangeResponse>('array')
         .FixToResponseModel(GetCronTickerGraphDataRangeResponse, (item) => {
@@ -115,11 +125,13 @@ const getTimeTickersGraphData = () => {
         requestAsync
     };
 }
+
 export const cronTickerService = {
     getCronTickers,
     updateCronTicker,
     addCronTicker,
     deleteCronTicker,
+    runCronTickerOnDemand,
     getTimeTickersGraphDataRange,
     getTimeTickersGraphDataRangeById,
     getTimeTickersGraphData

--- a/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
@@ -29,6 +29,7 @@ const getCronTickers = cronTickerService.getCronTickers()
 const getCronTickerRangeGraphDataById = cronTickerService.getTimeTickersGraphDataRangeById()
 const getCronTickersGraphDataAndParseToGraph = cronTickerService.getTimeTickersGraphData()
 const deleteCronTicker = cronTickerService.deleteCronTicker()
+const runCronTickerOnDemand = cronTickerService.runCronTickerOnDemand()
 
 const confirmDialog = useDialog<ConfirmDialogProps & { id: string }>().withComponent(
   () => import('@/components/common/ConfirmDialog.vue'),
@@ -157,6 +158,12 @@ const ShowCronTickerOccurrenceGraphData = async (
       selectedCronTickerGraphData.value = id
     })
   }
+}
+
+const RunCronTickerOnDemand = async (
+  id: string
+) => {
+  await runCronTickerOnDemand.requestAsync(id)
 }
 
 const addHubListeners = async () => {
@@ -522,6 +529,15 @@ watch(
                 @click="crudCronTickerDialog.open({ ...item, isFromDuplicate: false })"
               >
                 <v-icon color="amber">mdi-pencil</v-icon>
+              </v-btn>
+              <v-btn
+                icon
+                density="comfortable"
+                @click="RunCronTickerOnDemand(item.id)"
+              >
+                <v-icon color="light-green"
+                  >mdi-play-outline</v-icon
+                >
               </v-btn>
               <v-btn
                 @click="

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/TickerEFCorePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/TickerEFCorePersistenceProvider.cs
@@ -482,7 +482,7 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
             var cronTickerOccurrences = await query
                 .Where(x => ids.Contains(x.CronTickerId))
                 .Where(x => x.ExecutionTime >= now)
-                .OrderByDescending(x => x.ExecutionTime)
+                .OrderBy(x => x.ExecutionTime)
                 .ToListAsync(cancellationToken);
 
             cronTickerOccurrences = cronTickerOccurrences.DistinctBy(x => x.CronTickerId)

--- a/src/TickerQ.Utilities/Interfaces/ITickerDashboardRepository.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerDashboardRepository.cs
@@ -17,6 +17,7 @@ namespace TickerQ.Utilities.Interfaces
         Task<IList<TickerGraphData>> GetCronTickersGraphSpecificDataByIdAsync(Guid id, int pastDays, int futureDays,CancellationToken cancellationToken);
         Task<IList<Tuple<TickerStatus, int>>> GetCronTickerFullDataAsync(CancellationToken cancellationToken);
         Task<IList<CronTickerDto>> GetCronTickersAsync();
+        Task AddOnDemandCronTickerOccurrenceAsync(Guid id);
         Task<IList<CronTickerOccurrenceDto>> GetCronTickersOccurrencesAsync(Guid guid);
         Task<IList<CronOccurrenceTickerGraphData>> GetCronTickersOccurrencesGraphDataAsync(Guid guid);
         bool CancelTickerById(Guid tickerId);

--- a/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
+++ b/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
@@ -279,9 +279,17 @@ namespace TickerQ.Utilities.Managers
                     var existingOccurrence = cronTickerOccurrences
                         .FirstOrDefault(x => x.CronTickerId == vt.Item1 && x.LockHolder != LockHolder);
 
-                    var next = existingOccurrence != null
-                        ? schedule.GetNextOccurrence(existingOccurrence.ExecutionTime)
-                        : schedule.GetNextOccurrence(now);
+                    DateTime next;
+                    if (existingOccurrence != null)
+                    {
+                        next = existingOccurrence.LockHolder == null 
+                            ? existingOccurrence.ExecutionTime 
+                            : schedule.GetNextOccurrence(existingOccurrence.ExecutionTime);
+                    }
+                    else
+                    {
+                        next = schedule.GetNextOccurrence(now);
+                    }
 
                     return new
                     {


### PR DESCRIPTION
This adds the ability to run a cron ticker on demand via a button on the cron ticker table (Play button).

<img width="333" height="222" alt="image" src="https://github.com/user-attachments/assets/c3ad6e54-2d5b-4372-983e-d0f27977e421" />

It does so by adding a cron occurrence with an execution time of 1 second in the future (Similar to time tickers).

This does need more extensive testing, especially in multi-tenant environments as I currently don't have a multi-tenant test environment.

- Added new endpoint `/cron-ticker/:run` to trigger a cron ticker on demand
- Updated repository interface and implementation to add functionality for marking a cron ticker occurrence as on-demand
- Adjusted ordering of occurrences to prioritize non-delayed ones

Addresses #75