### PR TITLE
Merge branch 'main' of https://github.com/Arcenox-co/TickerQ

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Configurations/TimeTickerConfigurations.cs
+++ b/src/TickerQ.EntityFrameworkCore/Configurations/TimeTickerConfigurations.cs
@@ -17,7 +17,7 @@ namespace TickerQ.EntityFrameworkCore.Configurations
             builder.HasOne(e => e.ParentJob)
                 .WithMany(x => x.ChildJobs)
                 .HasForeignKey(x => x.BatchParent)
-                .OnDelete(DeleteBehavior.SetNull);
+                .OnDelete(DeleteBehavior.NoAction);
             
             builder.HasIndex("ExecutionTime")
                 .HasName("IX_TimeTicker_ExecutionTime");


### PR DESCRIPTION
PR Description
Title: Fix SQL Server self-referencing foreign key cascade delete issue
Description:
Problem
SQL Server doesn't allow SET NULL on self-referencing foreign keys because it could create multiple cascade paths. This occurs when a table has a foreign key that references itself (like TimeTickerEntity with BatchParent referencing the same table's Id), and SQL Server cannot determine the correct order for cascade operations.
Solution
Changed the delete behavior from the default cascade to NoAction for the self-referencing foreign key relationship in TimeTickerConfigurations.cs:
