### PR TITLE
#93 Dashboard displays incorrect executed at time after refresh (when…

### DIFF
--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerOccurrenceService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerOccurrenceService.ts
@@ -12,10 +12,14 @@ const getByCronTickerId = () => {
             
             response.status = Status[response.status as any];
 
-            if (response.executedAt != null || response.executedAt != undefined)
-                response.executedAt = `${format(response.executedAt)} (took ${formatTime(response.elapsedTime as number, true)})`;
+            if (response.executedAt != null || response.executedAt != undefined) {
+                // Ensure the datetime is treated as UTC by adding 'Z' if missing
+                const utcExecutedAt = response.executedAt.endsWith('Z') ? response.executedAt : response.executedAt + 'Z';
+                response.executedAt = `${format(utcExecutedAt)} (took ${formatTime(response.elapsedTime as number, true)})`;
+            }
 
-            response.executionTimeFormatted = formatDate(response.executionTime);
+            const utcExecutionTime = response.executionTime.endsWith('Z') ? response.executionTime : response.executionTime + 'Z';
+            response.executionTimeFormatted = formatDate(utcExecutionTime);
             response.lockedAt = formatDate(response.lockedAt)
             return response;
         })

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/timeTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/timeTickerService.ts
@@ -20,12 +20,16 @@ const getTimeTickers = () => {
         .FixToResponseModel(GetTimeTickerResponse, response => {
             response.status = Status[response.status as any];
 
-            if (response.executedAt != null || response.executedAt != undefined)
-                response.executedAt = `${format(response.executedAt)} (took ${formatTime(response.elapsedTime as number, true)})`;
+            if (response.executedAt != null || response.executedAt != undefined) {
+                // Ensure the datetime is treated as UTC by adding 'Z' if missing
+                const utcExecutedAt = response.executedAt.endsWith('Z') ? response.executedAt : response.executedAt + 'Z';
+                response.executedAt = `${format(utcExecutedAt)} (took ${formatTime(response.elapsedTime as number, true)})`;
+            }
 
-            response.executionTimeFormatted = formatDate(response.executionTime);
+            const utcExecutionTime = response.executionTime.endsWith('Z') ? response.executionTime : response.executionTime + 'Z';
+            response.executionTimeFormatted = formatDate(utcExecutionTime);
+
             response.requestType = functionNamesStore.getNamespaceOrNull(response.function) ?? 'N/A';
-
             response.description = response.description == '' ? 'N/A' : response.description;
 
             if (response.retryIntervals == null || response.retryIntervals.length == 0 && response.retries != null && (response.retries as number) > 0)


### PR DESCRIPTION
In my environment SQL Server was Azure SQL running in UTC, the testing iwas doing on the Dasboard was in my time zone +10.
When thea TimeTicker was created and exectuted SignalR would update the the Execution Time and Executad At with the correct time zone, after a page reload the times were incorect.

The fix was to just check and ensure the 'Z' was present in the data returned before passing into the format functions
