### PR TITLE
feat(dashboard): add tooltip to Cron Ticker page

### DIFF
--- a/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
@@ -480,7 +480,7 @@ const headersWithoutReadable = computed(() =>
             item-value="id"
             item-class="custom-row-class"
             density="compact"
-          >            
+          >
             <template v-slot:item.expression="{ item }">
                 <v-tooltip location="top">
                   <template #activator="{ props }">
@@ -514,61 +514,86 @@ const headersWithoutReadable = computed(() =>
                 ]
               </span>
             </template>
-            <template v-slot:item.actions="{ item }">
-              <v-btn
-                icon
-                density="comfortable"
-                @click="ShowCronTickerOccurrenceGraphData(item.function, item.id, -3, 3)"
-              >
-                <v-icon :color="selectedCronTickerGraphData == item.id ? 'grey' : 'light-blue'"
-                  >mdi-chart-areaspline</v-icon
-                >
-              </v-btn>
-              <v-btn
-                @click="
-                  cronOccurrenceDialog.open({
-                    id: item.id,
-                    retries: item.retries,
-                    retryIntervals: item.retryIntervals,
-                  })
-                "
-                icon
-                density="comfortable"
-              >
-                <v-icon color="light-blue">mdi-folder-open</v-icon>
-              </v-btn>
-              <v-btn
-                icon
-                density="comfortable"
-                @click="crudCronTickerDialog.open({ ...item, isFromDuplicate: false })"
-              >
-                <v-icon color="amber">mdi-pencil</v-icon>
-              </v-btn>
-              <v-btn
-                icon
-                density="comfortable"
-                @click="RunCronTickerOnDemand(item.id)"
-              >
-                <v-icon color="light-green"
-                  >mdi-play-outline</v-icon
-                >
-              </v-btn>
-              <v-btn
-                @click="
-                  confirmDialog.open({
-                    ...new ConfirmDialogProps(),
-                    id: item.id,
-                    showWarningAlert: item.initIdentifier != undefined ? true : false,
-                    warningAlertMessage:
-                      'System-seeded ticker. To remove permanently, delete its cron expression from code.',
-                  })
-                "
-                icon
-                density="comfortable"
-              >
-                <v-icon color="red-lighten-1">mdi-delete</v-icon>
-              </v-btn>
-            </template>
+              <template #item.actions="{ item }">
+               <v-tooltip text="History">
+                 <template #activator="{ props }">
+                   <v-btn
+                     icon
+                     density="comfortable"
+                     v-bind="props"
+                     @click="ShowCronTickerOccurrenceGraphData(item.function, item.id, -3, 3)"
+                   >
+                     <v-icon :color="selectedCronTickerGraphData == item.id ? 'grey' : 'light-blue'"
+                       >mdi-chart-areaspline</v-icon
+                     >
+                   </v-btn>
+                 </template>
+               </v-tooltip>
+               <v-tooltip text="Cron Occurrences">
+                 <template #activator="{ props }">
+                   <v-btn
+                     @click="
+                       cronOccurrenceDialog.open({
+                         id: item.id,
+                         retries: item.retries,
+                         retryIntervals: item.retryIntervals,
+                       })
+                     "
+                     icon
+                     density="comfortable"
+                     v-bind="props"
+                   >
+                     <v-icon color="light-blue">mdi-folder-open</v-icon>
+                   </v-btn>
+                 </template>
+               </v-tooltip>
+               <v-tooltip text="Edit Ticker">
+                 <template #activator="{ props }">
+                   <v-btn
+                     icon
+                     density="comfortable"
+                     v-bind="props"
+                     @click="crudCronTickerDialog.open({ ...item, isFromDuplicate: false })"
+                   >
+                     <v-icon color="amber">mdi-pencil</v-icon>
+                   </v-btn>
+                 </template>
+               </v-tooltip>
+                 <v-tooltip text="Run on demand">
+                  <template #activator="{ props }">
+                    <v-btn
+                      icon
+                      density="comfortable"
+                      v-bind="props"
+                      @click="RunCronTickerOnDemand(item.id)"
+                    >
+                      <v-icon color="light-green"
+                        >mdi-play-outline</v-icon
+                      >
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+                <v-tooltip text="Delete Ticker">
+                  <template #activator="{ props }">
+                    <v-btn
+                      @click="
+                        confirmDialog.open({
+                          ...new ConfirmDialogProps(),
+                          id: item.id,
+                          showWarningAlert: item.initIdentifier != undefined ? true : false,
+                          warningAlertMessage:
+                            'System-seeded ticker. To remove permanently, delete its cron expression from code.',
+                        })
+                      "
+                      icon
+                      density="comfortable"
+                      v-bind="props"
+                    >
+                      <v-icon color="red-lighten-1">mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+             </template>
           </v-data-table>
         </v-sheet>
       </v-col>


### PR DESCRIPTION
This was only added for the Cron tickers page.
If we like this idea, we can propagate it to the time ticker page.

This is how it looks like:
<img width="217" height="73" alt="image" src="https://github.com/user-attachments/assets/3250d4e5-a91d-49b0-8b19-8cef3b3aa295" />

<img width="260" height="74" alt="image" src="https://github.com/user-attachments/assets/2600bbc6-9aea-4e62-af0b-52edf3ededa4" />

<img width="255" height="77" alt="image" src="https://github.com/user-attachments/assets/9c137b2a-4787-45a4-b6ff-fe7fa5c09cc9" />

<img width="294" height="67" alt="image" src="https://github.com/user-attachments/assets/90f717ee-acbc-49f7-bd20-01c52555588b" />

<img width="186" height="70" alt="image" src="https://github.com/user-attachments/assets/729f8177-78ea-45d2-b428-74381ef7d8d8" />


