### PR TITLE
feat(dashboard): add tooltips for time ticker view.

### DIFF
--- a/src/TickerQ.Dashboard/wwwroot/src/views/TimeTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/TimeTicker.vue
@@ -887,44 +887,68 @@ watch(
               </template>
 
               <template v-slot:item.actions="{ item }">
-                <v-btn
-                  @click="requestCancel(item.id)"
-                  :disabled="!hasStatus(item.status, Status.InProgress)"
-                  icon
-                  :variant="hasStatus(item.status, Status.InProgress) ? 'elevated' : 'text'"
-                  density="comfortable"
-                >
-                  <v-icon :color="hasStatus(item.status, Status.InProgress) ? 'blue' : 'grey'"
-                  >mdi-cancel</v-icon
-                  >
-                </v-btn>
-                <v-btn
-                  v-if="
-                    hasStatus(item.status, Status.Queued) || hasStatus(item.status, Status.Idle)
-                  "
-                  icon
-                  density="comfortable"
-                  @click="crudTimeTickerDialog.open({ ...item, executionTime: formatFromUtcToLocal(item.executionTime), isFromDuplicate: false })"
-                >
-                  <v-icon color="amber">mdi-pencil</v-icon>
-                </v-btn>
-                <v-btn
-                  v-else
-                  icon
-                  density="comfortable"
-                  @click="crudTimeTickerDialog.open({ ...item, executionTime: formatFromUtcToLocal(item.executionTime), isFromDuplicate: true })"
-                >
-                  <v-icon color="grey">mdi-plus-box-multiple-outline</v-icon>
-                </v-btn>
-                <v-btn
-                  @click="confirmDialog.open({ id: item.id })"
-                  :disabled="hasStatus(item.status, Status.InProgress)"
-                  :variant="!hasStatus(item.status, Status.InProgress) ? 'elevated' : 'text'"
-                  icon
-                  density="comfortable"
-                >
-                  <v-icon color="red">mdi-delete</v-icon>
-                </v-btn>
+
+                <v-tooltip text="Cancel Ticker">
+                  <template #activator="{ props }">
+                      <v-btn
+                        v-bind="props"
+                        @click="requestCancel(item.id)"
+                        :disabled="!hasStatus(item.status, Status.InProgress)"
+                        icon
+                        :variant="hasStatus(item.status, Status.InProgress) ? 'elevated' : 'text'"
+                        density="comfortable"
+                      >
+                        <v-icon :color="hasStatus(item.status, Status.InProgress) ? 'blue' : 'grey'"
+                        >mdi-cancel</v-icon
+                        >
+                      </v-btn>
+                  </template>
+                </v-tooltip>
+
+
+                <v-tooltip text="Edit Ticker"
+                  v-if="hasStatus(item.status, Status.Queued) || hasStatus(item.status, Status.Idle)">
+                  <template #activator="{ props }">
+                    <v-btn
+                      v-bind="props"
+                      icon
+                      density="comfortable"
+                      @click="crudTimeTickerDialog.open({ ...item, executionTime: formatFromUtcToLocal(item.executionTime), isFromDuplicate: false })"
+                    >
+                      <v-icon color="amber">mdi-pencil</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+
+                <v-tooltip text="Duplicate Ticker"
+                  v-else>
+                  <template #activator="{ props }">
+                    <v-btn
+                      v-bind="props"
+                      icon
+                      density="comfortable"
+                      @click="crudTimeTickerDialog.open({ ...item, executionTime: formatFromUtcToLocal(item.executionTime), isFromDuplicate: true })"
+                    >
+                      <v-icon color="grey">mdi-plus-box-multiple-outline</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+
+                <v-tooltip text="Delete Ticker">
+                  <template #activator="{ props }">
+                    <v-btn
+                      v-bind="props"
+                      @click="confirmDialog.open({ id: item.id })"
+                      :disabled="hasStatus(item.status, Status.InProgress)"
+                      :variant="!hasStatus(item.status, Status.InProgress) ? 'elevated' : 'text'"
+                      icon
+                      density="comfortable"
+                    >
+                      <v-icon color="red">mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+
               </template>
             </v-data-table>
           </v-sheet>


### PR DESCRIPTION
This is how it looks:
<img width="192" height="113" alt="Screenshot 2025-08-05 173835" src="https://github.com/user-attachments/assets/f8dfbac4-2883-4b8c-a008-d520ab96a211" />
<img width="199" height="76" alt="Screenshot 2025-08-05 175616" src="https://github.com/user-attachments/assets/dc38c65c-e828-4480-9687-6e93ae384707" />
<img width="193" height="82" alt="Screenshot 2025-08-05 175624" src="https://github.com/user-attachments/assets/61bc1ec6-a506-4ec8-84b4-53643d03bdec" />
<img width="269" height="119" alt="Screenshot 2025-08-05 175643" src="https://github.com/user-attachments/assets/8ced9b2f-6315-43dd-8164-cf49d758542f" />

