### PR TITLE
Added example in readme to start TickerQ manually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ app.UseTickerQ(TickerQStartMode.Manual);
 
 ITickerHost tickerHost = app.Services.GetRequiredService<ITickerHost>(); // Resolve the Singleton service ITickerHost from the IServiceProvider.
 
-tickerHost.Start(); // Invoke the start method to manual start TickerQ
+tickerHost.Start(); // Invoke the start method to manually start TickerQ
 ```
 ---
 


### PR DESCRIPTION
Adds an example to the README.md file illustrating a manual start using the `ITickerHost` service.

closes #163 
