### PR TITLE
feat(dashboard): add pagination to declared functions and used machines

### DIFF
--- a/src/TickerQ.Dashboard/wwwroot/src/views/Dashboard.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/Dashboard.vue
@@ -155,6 +155,9 @@ const functionItems: Ref<
     priority: string
   }>
 > = ref([])
+
+// Pagination configuration
+const defaultItemsPerPage = 10
 </script>
 <template>
   <v-container fluid>
@@ -285,7 +288,11 @@ const functionItems: Ref<
         <v-row class="mt-2">
           <v-col cols="8">
             <v-card-title> Declared Functions </v-card-title>
-            <v-data-table hide-default-footer density="compact" :items="functionItems">
+            <v-data-table
+              density="compact"
+              :items="functionItems"
+              :items-per-page="defaultItemsPerPage"
+            >
               <template #item.request="{ item }">
                 <div class="text-truncate" style="max-width: 200px">
                   {{ item.request }}
@@ -296,9 +303,9 @@ const functionItems: Ref<
           <v-col cols="4">
             <v-card-title> Used Machines </v-card-title>
             <v-data-table
-              hide-default-footer
               density="compact"
               :items="machineItems"
+              :items-per-page="defaultItemsPerPage"
             ></v-data-table>
           </v-col>
         </v-row>


### PR DESCRIPTION
This is how it looks like now:
<img width="2504" height="1266" alt="image" src="https://github.com/user-attachments/assets/94fc0757-5966-4b92-9095-d18feee6a38c" />


This would close #151 