### PR TITLE
Border Radius table style fix

### DIFF
--- a/src/TickerQ.Dashboard/wwwroot/src/views/Dashboard.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/Dashboard.vue
@@ -871,7 +871,7 @@ const getVisiblePageNumbers = () => {
 /* Premium Table */
 .table-container {
   background: rgba(0, 0, 0, 0.2);
-  border-radius: 8px;
+  border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
Crisper border radius on tables fixing the corners.

Before
<img width="1136" height="551" alt="image" src="https://github.com/user-attachments/assets/5ebe7ff6-8bf0-4e7a-bbf6-4b4c3580de83" />

After
<img width="1136" height="551" alt="image" src="https://github.com/user-attachments/assets/c70c699f-1359-4536-9acd-e353e3e808d4" />

Sorry about my OCD.
