### PR TITLE
Enhance UseTickerSeeder

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
+++ b/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
@@ -25,6 +25,18 @@ namespace TickerQ.EntityFrameworkCore
             return this;
         }
 
+        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(Func<ITimeTickerManager<TTimeTicker>, Task> timeTickerAsync)
+        {
+            TimeSeeder = async t => await timeTickerAsync(t);
+            return this;
+        }
+
+        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(Func<ICronTickerManager<TCronTicker>, Task> cronTickerAsync)
+        {
+            CronSeeder = async c => await cronTickerAsync(c);
+            return this;
+        }
+
         public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(Func<ITimeTickerManager<TTimeTicker>, Task> timeTickerAsync, Func<ICronTickerManager<TCronTicker>, Task> cronTickerAsync)
         {
             TimeSeeder = async t => await timeTickerAsync(t);


### PR DESCRIPTION
In this PR, I added two additional methods to the `UseTickerSeeder` implementation, allowing it to accept either a time ticker or a cron ticker independently.

This enhancement ensures that users are not required to provide both types of tickers when seeding during service registration, offering greater flexibility and cleaner configuration.

While it’s technically possible to modify the existing method to accept `null` values, doing so would allow a scenario where both parameters are `null`, making the method call meaningless. To avoid this and maintain clear intent, I introduced two separate methods instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two `UseTickerSeeder` overloads to allow seeding time or cron tickers independently.
> 
> - **EF Core options (`src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs`)**:
>   - **API**: Add overloads of `UseTickerSeeder`
>     - `UseTickerSeeder(Func<ITimeTickerManager<TTimeTicker>, Task>)` to seed time tickers only.
>     - `UseTickerSeeder(Func<ICronTickerManager<TCronTicker>, Task>)` to seed cron tickers only.
>   - Existing combined overload remains: `UseTickerSeeder(Func<ITimeTickerManager<TTimeTicker>, Task>, Func<ICronTickerManager<TCronTicker>, Task>)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb541e1a7e8c74ac389ffc74b58844e50ac6d5b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->