### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/.github/workflows/sync-version-branches.yml
+++ b/.github/workflows/sync-version-branches.yml
@@ -121,27 +121,36 @@ jobs:
               fi
             done
 
-            # Reset .csproj files to target branch versions
-            echo "📝 Resetting .csproj files to ${{ matrix.target_branch }} versions..."
+            # Reset .csproj files and Directory.Build.props to target branch versions
+            echo "📝 Resetting .csproj files and Directory.Build.props to ${{ matrix.target_branch }} versions..."
             find . -name "*.csproj" -type f -exec git checkout ${{ matrix.target_branch }} -- {} \;
-
-            # Update version and target framework in Directory.Build.props
-            dotnet_version=$(echo "${{ matrix.target_branch }}" | sed 's/[^0-9]*//g')
-            echo "dotnet_version=$dotnet_version" >> $GITHUB_ENV
+            
+            # Also reset Directory.Build.props to keep the net8 version
             if [ -f "src/Directory.Build.props" ]; then
-              echo "🔄 Updating version and target framework to .NET $dotnet_version..."
-              # Update version number (9.0.x → 8.0.x)
-              sed -i "s/<Version>9\.0\./<Version>$dotnet_version.0./g" src/Directory.Build.props
-              # Update target framework (net9.0 → net8.0)
-              sed -i "s/<TargetFramework>net9\.0</<TargetFramework>net$dotnet_version.0</g" src/Directory.Build.props
+              echo "📝 Resetting Directory.Build.props to ${{ matrix.target_branch }} version..."
+              git checkout ${{ matrix.target_branch }} -- src/Directory.Build.props
+              
+              echo "Directory.Build.props from ${{ matrix.target_branch }}:"
+              grep -E "<Version>|<TargetFramework>" src/Directory.Build.props
             fi
 
+            
             # Stage all changes
             git add -A
+            
+            # Show what files have changes
+            echo "📋 Files with changes after cherry-pick and reset:"
+            git diff --cached --name-status
+            
+            # Show actual changes
+            echo "📝 Actual changes to be committed:"
+            git diff --cached --stat
 
             # Check if there are changes to commit
             if git diff --cached --quiet; then
               echo "ℹ️  No changes to commit after processing"
+              echo "This means all changes from main are already in ${{ matrix.target_branch }}"
+              echo "or only affected .csproj/Directory.Build.props files which we reset."
               git checkout main
               git branch -D "$sync_branch"
               exit 0


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main
- ✅ Updated version numbers (9.0.x → 8.0.x for net8 branch)
- ✅ Updated target framework (net9.0 → net8.0 for net8 branch)
- ✅ Preserved .csproj files from net8 branch

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines sync workflow to reset `*.csproj` and `Directory.Build.props` from the target branch, adds verification and diff previews, and clarifies no-op cases.
> 
> - **CI Workflow (`.github/workflows/sync-version-branches.yml`)**:
>   - **Reset strategy**: After cherry-picking, reset both `*.csproj` and `src/Directory.Build.props` to the target branch versions (replaces inline `sed` edits for version/framework).
>   - **Verification**: Print `Version` and `TargetFramework` from `Directory.Build.props` for visibility.
>   - **Commit preview**: Stage all changes and show `git diff --cached` name-status and stats before committing.
>   - **No-op clarity**: Add messages clarifying when no changes remain because only project/props files were reset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9abe8472abca5b6d1a82b102c3cfa755674b2ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->