### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ public class CleanupJobs(ICleanUpService cleanUpService)
 {
     private readonly ICleanUpService _cleanUpService = cleanUpService;
 
-    [TickerFunction(functionName: "CleanupLogs", cronExpression: "0 0 * * *" )]
+    [TickerFunction(functionName: "CleanupLogs", cronExpression: "0 0 0 * * *" )]
     public asynt Task CleanupLogs(TickerFunctionContext<string> tickerContext, CancellationToken cancellationToken)
     {
         var logFileName = tickerContext.Request; // output cleanup_example_file.txt
@@ -131,27 +131,20 @@ public class CleanupJobs(ICleanUpService cleanUpService)
 
 > This uses a cron expression to run daily at midnight.
 
-#### 📅 Cron Expression Formats
+#### 📅 Cron Expression Format
 
-TickerQ supports both **5-part** and **6-part** cron expressions:
+TickerQ uses **6-part** cron expressions with seconds precision:
 
-**5-part format (standard):**
-```
-minute hour day month day-of-week
-```
-Examples:
-- `"0 0 * * *"` - Daily at midnight
-- `"0 */6 * * *"` - Every 6 hours
-- `"30 14 * * 1"` - Every Monday at 2:30 PM
-
-**6-part format (with seconds):**
 ```
 second minute hour day month day-of-week
 ```
+
 Examples:
 - `"0 0 0 * * *"` - Daily at midnight (00:00:00)
 - `"30 0 0 * * *"` - Daily at 00:00:30 (30 seconds past midnight)
 - `"0 0 */2 * * *"` - Every 2 hours on the hour
+- `"0 0 */6 * * *"` - Every 6 hours
+- `"0 30 14 * * 1"` - Every Monday at 2:30 PM
 - `"*/10 * * * * *"` - Every 10 seconds
 
 ---
@@ -180,10 +173,10 @@ Schedule Cron Ticker:
 await _cronTickerManager.AddAsync(new CronTicker
 {
     Function = "CleanupLogs",
-    Expression = "0 */6 * * *", // Every 6 hours (5-part format)
-    // Or use 6-part format with seconds:
-    // Expression = "0 0 */6 * * *", // Every 6 hours at :00:00
+    Expression = "0 0 */6 * * *", // Every 6 hours at :00:00
+    // Other examples:
     // Expression = "*/30 * * * * *", // Every 30 seconds
+    // Expression = "0 0 0 * * *", // Daily at midnight
     Request = TickerHelper.CreateTickerRequest<string>("cleanup_example_file.txt"),
     Retries = 2,
     RetryIntervals = new[] { 60, 300 }

--- a/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
+++ b/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using TickerQ.Dashboard.Authentication;
@@ -19,6 +20,12 @@ public class DashboardOptionsBuilder
     public Action<IApplicationBuilder> CustomMiddleware { get; set; }
     public Action<IApplicationBuilder> PreDashboardMiddleware { get; set; }
     public Action<IApplicationBuilder> PostDashboardMiddleware { get; set; }
+    
+    /// <summary>
+    /// JsonSerializerOptions specifically for Dashboard API endpoints.
+    /// Separate from request serialization options to prevent user configuration from breaking dashboard APIs.
+    /// </summary>
+    internal JsonSerializerOptions DashboardJsonOptions { get; set; }
     
     public void SetCorsPolicy(Action<CorsPolicyBuilder> corsPolicyBuilder)
         => CorsPolicyBuilder = corsPolicyBuilder;
@@ -71,6 +78,19 @@ public class DashboardOptionsBuilder
     public DashboardOptionsBuilder WithSessionTimeout(int minutes)
     {
         Auth.SessionTimeoutMinutes = minutes;
+        return this;
+    }
+    
+    /// <summary>
+    /// Configure JSON serialization options for Dashboard API endpoints.
+    /// These are separate from request serialization to maintain dashboard integrity.
+    /// </summary>
+    /// <param name="configure">Action to configure JsonSerializerOptions for dashboard APIs</param>
+    /// <returns>The DashboardOptionsBuilder for method chaining</returns>
+    public DashboardOptionsBuilder ConfigureDashboardJsonOptions(Action<JsonSerializerOptions> configure)
+    {
+        DashboardJsonOptions ??= new JsonSerializerOptions();
+        configure?.Invoke(DashboardJsonOptions);
         return this;
     }
     

--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using TickerQ.Dashboard.Authentication;
 using TickerQ.Dashboard.Endpoints;
+using TickerQ.Dashboard.Infrastructure;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using TickerQ.Utilities.Entities;
@@ -21,6 +22,24 @@ namespace TickerQ.Dashboard.DependencyInjection
             where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
             where TCronTicker : CronTickerEntity, new()
         {
+            // Configure default Dashboard JSON options if not already configured
+            if (config.DashboardJsonOptions == null)
+            {
+                config.DashboardJsonOptions = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    Converters = { new StringToByteArrayConverter() }
+                };
+            }
+            else
+            {
+                // Ensure StringToByteArrayConverter is always present
+                if (!config.DashboardJsonOptions.Converters.Any(c => c is StringToByteArrayConverter))
+                {
+                    config.DashboardJsonOptions.Converters.Add(new StringToByteArrayConverter());
+                }
+            }
+            
             // Register the dashboard configuration for DI
             services.AddSingleton(config);
             services.AddSingleton(config.Auth);

--- a/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
+++ b/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
@@ -294,6 +294,7 @@ public static class DashboardEndpoints
     private static async Task<IResult> CreateChainJobs<TTimeTicker, TCronTicker>(
         HttpContext context,
         ITimeTickerManager<TTimeTicker> timeTickerManager,
+        DashboardOptionsBuilder dashboardOptions,
         CancellationToken cancellationToken)
         where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
         where TCronTicker : CronTickerEntity, new()
@@ -302,15 +303,8 @@ public static class DashboardEndpoints
         using var reader = new StreamReader(context.Request.Body);
         var jsonString = await reader.ReadToEndAsync(cancellationToken);
         
-        // Create JsonSerializerOptions with our custom converter for this endpoint only
-        var jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-            Converters = { new StringToByteArrayConverter() }
-        };
-        
-        // Deserialize with custom converter
-        var chainRoot = JsonSerializer.Deserialize<TTimeTicker>(jsonString, jsonOptions);
+        // Use Dashboard-specific JSON options
+        var chainRoot = JsonSerializer.Deserialize<TTimeTicker>(jsonString, dashboardOptions.DashboardJsonOptions);
         
         var result = await timeTickerManager.AddAsync(chainRoot, cancellationToken);
         

--- a/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
@@ -25,11 +25,15 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
         private readonly TickerExecutionContext _executionContext;
         private readonly ITimeTickerManager<TTimeTicker>  _timeTickerManager;
         private readonly ITickerClock _clock;
+        private readonly DashboardOptionsBuilder _dashboardOptions;
         public TickerDashboardRepository(
             TickerExecutionContext executionContext,
             ITickerPersistenceProvider<TTimeTicker, TCronTicker> persistenceProvider,
             ITickerQHostScheduler tickerQHostScheduler, 
-            ITickerQNotificationHubSender notificationHubSender, ITimeTickerManager<TTimeTicker> timeTickerManager, ITickerClock clock)
+            ITickerQNotificationHubSender notificationHubSender, 
+            ITimeTickerManager<TTimeTicker> timeTickerManager, 
+            ITickerClock clock,
+            DashboardOptionsBuilder dashboardOptions)
         {
             _persistenceProvider = persistenceProvider ?? throw new ArgumentNullException(nameof(persistenceProvider));
             _tickerQHostScheduler = tickerQHostScheduler ?? throw new ArgumentNullException(nameof(tickerQHostScheduler));
@@ -37,6 +41,7 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
             _timeTickerManager = timeTickerManager;
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _executionContext = executionContext ??  throw new ArgumentNullException(nameof(executionContext));
+            _dashboardOptions = dashboardOptions ?? throw new ArgumentNullException(nameof(dashboardOptions));
         }
 
         public async Task<TTimeTicker[]> GetTimeTickersAsync(CancellationToken cancellationToken)
@@ -669,7 +674,7 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
                     out var functionTypeContext)) return (jsonRequest, 2);
             try
             {
-                JsonSerializer.Deserialize(jsonRequest, functionTypeContext.Item2);
+                JsonSerializer.Deserialize(jsonRequest, functionTypeContext.Item2, _dashboardOptions.DashboardJsonOptions);
                 return (jsonRequest, 1);
             }
             catch
@@ -760,7 +765,7 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
             // Process the request using the function
             if (!string.IsNullOrWhiteSpace(request.Request))
             {
-                var serializedRequest = JsonSerializer.Deserialize<object>(request.Request);
+                var serializedRequest = JsonSerializer.Deserialize<object>(request.Request, _dashboardOptions.DashboardJsonOptions);
                 cronTicker.Request = TickerHelper.CreateTickerRequest(serializedRequest);
             }
             

--- a/src/TickerQ.SourceGenerator/Validation/CronValidator.cs
+++ b/src/TickerQ.SourceGenerator/Validation/CronValidator.cs
@@ -5,16 +5,12 @@ namespace TickerQ.SourceGenerator.Validation
 {
     public static class CronValidator
     {
-        // Format with seconds (6 parts): seconds, minutes, hours, day, month, day-of-week
-        private static readonly int[] MinValuesArray6Part = { 0, 0, 0, 1, 1, 0 };
-        private static readonly int[] MaxValuesArray6Part = { 59, 59, 23, 31, 12, 6 };
-        
-        // Format without seconds (5 parts): minutes, hours, day, month, day-of-week
-        private static readonly int[] MinValuesArray5Part = { 0, 0, 1, 1, 0 };
-        private static readonly int[] MaxValuesArray5Part = { 59, 23, 31, 12, 6 };
+        // Format with seconds (6 parts only): seconds, minutes, hours, day, month, day-of-week
+        private static readonly int[] MinValues = { 0, 0, 0, 1, 1, 0 };
+        private static readonly int[] MaxValues = { 59, 59, 23, 31, 12, 6 };
         
         // Performance constants
-        private const int MaxPartsCount = 6;
+        private const int RequiredPartsCount = 6;
 
         public static bool IsValidCronExpression(string expression)
         {
@@ -22,23 +18,18 @@ namespace TickerQ.SourceGenerator.Validation
 
             // Use Span for efficient string splitting without allocations
             var expressionSpan = expression.AsSpan();
-            var parts = new string[MaxPartsCount];
+            var parts = new string[RequiredPartsCount];
             var partCount = SplitIntoSpan(expressionSpan, parts);
             
-            // Support both 5-part (without seconds) and 6-part (with seconds) cron expressions
-            if (partCount != 5 && partCount != 6) 
+            // Only support 6-part cron expressions with seconds
+            if (partCount != RequiredPartsCount) 
                 return false;
 
-            // Select appropriate min/max values based on part count
-            ReadOnlySpan<int> minSpan = partCount == 6 
-                ? MinValuesArray6Part 
-                : MinValuesArray5Part;
+            // Validate each part with corresponding min/max values
+            ReadOnlySpan<int> minSpan = MinValues;
+            ReadOnlySpan<int> maxSpan = MaxValues;
             
-            ReadOnlySpan<int> maxSpan = partCount == 6 
-                ? MaxValuesArray6Part 
-                : MaxValuesArray5Part;
-            
-            for (int i = 0; i < partCount; i++)
+            for (int i = 0; i < RequiredPartsCount; i++)
             {
                 if (!ValidatePart(parts[i], minSpan[i], maxSpan[i]))
                     return false;

--- a/src/TickerQ.Utilities/TickerHelper.cs
+++ b/src/TickerQ.Utilities/TickerHelper.cs
@@ -9,6 +9,12 @@ namespace TickerQ.Utilities
     public static class TickerHelper
     {
         private static readonly byte[] GZipSignature = [0x1f, 0x8b, 0x08, 0x00];
+        
+        /// <summary>
+        /// JsonSerializerOptions specifically for ticker request serialization/deserialization.
+        /// Can be configured during application startup via TickerOptionsBuilder.
+        /// </summary>
+        public static JsonSerializerOptions RequestJsonSerializerOptions { get; set; } = new JsonSerializerOptions();
 
         public static byte[] CreateTickerRequest<T>(T data)
         {
@@ -22,7 +28,7 @@ namespace TickerQ.Utilities
             Span<byte> compressedBytes;
             var serialized = data is byte[] bytes
                 ? bytes
-                : JsonSerializer.SerializeToUtf8Bytes(data);
+                : JsonSerializer.SerializeToUtf8Bytes(data, RequestJsonSerializerOptions);
             
             using (var memoryStream = new MemoryStream())
             {
@@ -46,7 +52,7 @@ namespace TickerQ.Utilities
         {
             var serializedObject = ReadTickerRequestAsString(gzipBytes);
             
-            return JsonSerializer.Deserialize<T>(serializedObject);
+            return JsonSerializer.Deserialize<T>(serializedObject, RequestJsonSerializerOptions);
         }
         
         public static string ReadTickerRequestAsString(byte[] gzipBytes)

--- a/src/TickerQ.Utilities/TickerOptionsBuilder.cs
+++ b/src/TickerQ.Utilities/TickerOptionsBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using TickerQ.Utilities.Entities;
@@ -26,6 +27,25 @@ namespace TickerQ.Utilities
         public TickerOptionsBuilder<TTimeTicker, TCronTicker> ConfigureScheduler(Action<SchedulerOptionsBuilder> schedulerOptionsBuilder)
         {
             schedulerOptionsBuilder?.Invoke(_schedulerOptions);
+            return this;
+        }
+
+              
+        /// <summary>
+        /// JsonSerializerOptions specifically for serializing/deserializing ticker requests.
+        /// If not set, default JsonSerializerOptions will be used.
+        /// </summary>
+        internal JsonSerializerOptions RequestJsonSerializerOptions { get; set; }
+        
+        /// <summary>
+        /// Configures the JSON serialization options specifically for ticker request serialization/deserialization.
+        /// </summary>
+        /// <param name="configure">Action to configure JsonSerializerOptions for ticker requests</param>
+        /// <returns>The TickerOptionsBuilder for method chaining</returns>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> ConfigureRequestJsonOptions(Action<JsonSerializerOptions> configure)
+        {
+            RequestJsonSerializerOptions ??= new JsonSerializerOptions();
+            configure?.Invoke(RequestJsonSerializerOptions);
             return this;
         }
         

--- a/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
+++ b/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
@@ -32,6 +32,12 @@ namespace TickerQ.DependencyInjection
             var optionInstance = new TickerOptionsBuilder<TTimeTicker,TCronTicker>(tickerExecutionContext, schedulerOptionsBuilder);
             optionsBuilder?.Invoke(optionInstance);
             CronScheduleCache.TimeZoneInfo = schedulerOptionsBuilder.SchedulerTimeZone;
+            
+            // Apply JSON serializer options for ticker requests if configured during service registration
+            if (optionInstance.RequestJsonSerializerOptions != null)
+            {
+                TickerHelper.RequestJsonSerializerOptions = optionInstance.RequestJsonSerializerOptions;
+            }
             services.AddSingleton<ITimeTickerManager<TTimeTicker>, TickerManager<TTimeTicker, TCronTicker>>();
             services.AddSingleton<ICronTickerManager<TCronTicker>, TickerManager<TTimeTicker, TCronTicker>>();
             services.AddSingleton<IInternalTickerManager, InternalTickerManager<TTimeTicker, TCronTicker>>();


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main
- ✅ Updated version numbers (9.0.x → 8.0.x for net8 branch)
- ✅ Updated target framework (net9.0 → net8.0 for net8 branch)
- ✅ Preserved .csproj files from net8 branch

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce configurable JSON serializer options for dashboard APIs and ticker requests, and standardize cron to 6-part format with docs and validation updates.
> 
> - **Docs**:
>   - Update README to use 6-part cron (`seconds minutes hours day month day-of-week`), adjust examples, and midnight cron in `TickerFunction` attribute and scheduling snippets.
> - **Dashboard**:
>   - Add `DashboardOptionsBuilder.DashboardJsonOptions` and `ConfigureDashboardJsonOptions(...)` for API serialization.
>   - Initialize default dashboard JSON options and ensure `StringToByteArrayConverter` is present in DI setup.
>   - Use dashboard JSON options for deserialization in `DashboardEndpoints.CreateChainJobs` and `TickerDashboardRepository` (request parsing and cron update request handling).
> - **Core Utilities**:
>   - Add `TickerHelper.RequestJsonSerializerOptions` and use it in `CreateTickerRequest`/`ReadTickerRequest`.
>   - Extend `TickerOptionsBuilder` with `ConfigureRequestJsonOptions(...)`; apply in `AddTickerQ` to set `TickerHelper` options.
> - **Source Generator**:
>   - Simplify `CronValidator` to accept only 6-part cron expressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a63f4bcc7352d929153f8cc138f2db9f4bc4080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->