### PR TITLE
updated source generator to netstandard2.0

### DIFF
--- a/src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj
+++ b/src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>8.0</LangVersion>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <AssemblyName>TickerQ.SourceGenerator</AssemblyName>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -11,5 +13,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.10.0,)"/>
+        <PackageReference Include="System.Memory" Version="4.5.5" />
     </ItemGroup>
 </Project>

--- a/src/TickerQ.SourceGenerator/TickerQIncrementalSourceGenerator.cs
+++ b/src/TickerQ.SourceGenerator/TickerQIncrementalSourceGenerator.cs
@@ -317,14 +317,14 @@ namespace TickerQ.SourceGenerator
                     continue;
                     
                 var simpleName = fullTypeName.Contains('.') ? 
-                    fullTypeName[(fullTypeName.LastIndexOf('.') + 1)..] : 
+                    fullTypeName.Substring(fullTypeName.LastIndexOf('.') + 1) : 
                     fullTypeName;
                     
                 simpleNameCounts[simpleName] = simpleNameCounts.TryGetValue(simpleName, out var count) ? count + 1 : 1;
             }
             
             // Return simple names that have conflicts (count > 1)
-            return [..simpleNameCounts.Where(kv => kv.Value > 1).Select(kv => kv.Key)];
+            return new HashSet<string>(simpleNameCounts.Where(kv => kv.Value > 1).Select(kv => kv.Key));
         }
 
 
@@ -712,10 +712,10 @@ namespace TickerQ.SourceGenerator
                 {
                     var name = attr.AttributeClass?.Name;
                     var fullName = attr.AttributeClass?.ToDisplayString();
-                    return name == "FromKeyedServicesAttribute" || 
+                    return name == SourceGeneratorConstants.FromKeyedServicesAttributeName || 
                            name == "FromKeyedServices" ||
                            fullName == "Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute" ||
-                           fullName?.EndsWith("FromKeyedServicesAttribute") == true;
+                           fullName?.EndsWith(SourceGeneratorConstants.FromKeyedServicesAttributeName) == true;
                 });
 
             if (keyedServiceAttribute != null)

--- a/src/TickerQ.SourceGenerator/Utilities/SourceGeneratorConstants.cs
+++ b/src/TickerQ.SourceGenerator/Utilities/SourceGeneratorConstants.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace TickerQ.SourceGenerator.Utilities
 {
@@ -30,17 +31,17 @@ namespace TickerQ.SourceGenerator.Utilities
         public const int InitialStringBuilderCapacity = 8192; // Pre-allocate reasonable capacity
         
         public static readonly string[] CommonNamespaces =
-        [
+        {
             "System",
             "System.Collections.Generic", 
             "System.Threading",
             "System.Threading.Tasks",
             "Microsoft.Extensions.DependencyInjection"
-        ];
+        };
         
         // Pre-computed common variable names for performance (static readonly for better memory usage)
-        public static readonly System.Collections.Generic.HashSet<string> CommonVariableNames = 
-            new(StringComparer.Ordinal)
+        public static readonly HashSet<string> CommonVariableNames = 
+            new HashSet<string>(StringComparer.Ordinal)
         {
             "context", "service", "serviceProvider", "tickerFunctionDelegateDict",
             "cancellationToken", "genericContext", "requestTypes", "args",

--- a/src/TickerQ.SourceGenerator/Utilities/SourceGeneratorUtilities.cs
+++ b/src/TickerQ.SourceGenerator/Utilities/SourceGeneratorUtilities.cs
@@ -103,18 +103,27 @@ namespace TickerQ.SourceGenerator.Utilities
         /// </summary>
         private static string FormatServiceKeyValue(object value, ITypeSymbol type)
         {
-            return value switch
+            switch (value)
             {
-                double d => d.ToString("G", System.Globalization.CultureInfo.InvariantCulture) + "D",
-                float f => f.ToString("G", System.Globalization.CultureInfo.InvariantCulture) + "F",
-                decimal m => m.ToString("G", System.Globalization.CultureInfo.InvariantCulture) + "M",
-                long l => l.ToString(System.Globalization.CultureInfo.InvariantCulture) + "L",
-                uint ui => ui.ToString(System.Globalization.CultureInfo.InvariantCulture) + "U",
-                ulong ul => ul.ToString(System.Globalization.CultureInfo.InvariantCulture) + "UL",
-                char c => $"'{c}'",
-                bool b => b ? "true" : "false",
-                _ => value.ToString(),
-            };
+                case double d:
+                    return d.ToString("G", System.Globalization.CultureInfo.InvariantCulture) + "D";
+                case float f:
+                    return f.ToString("G", System.Globalization.CultureInfo.InvariantCulture) + "F";
+                case decimal m:
+                    return m.ToString("G", System.Globalization.CultureInfo.InvariantCulture) + "M";
+                case long l:
+                    return l.ToString(System.Globalization.CultureInfo.InvariantCulture) + "L";
+                case uint ui:
+                    return ui.ToString(System.Globalization.CultureInfo.InvariantCulture) + "U";
+                case ulong ul:
+                    return ul.ToString(System.Globalization.CultureInfo.InvariantCulture) + "UL";
+                case char c:
+                    return $"'{c}'";
+                case bool b:
+                    return b ? "true" : "false";
+                default:
+                    return value.ToString();
+            }
         }
 
         /// <summary>
@@ -158,7 +167,7 @@ namespace TickerQ.SourceGenerator.Utilities
         {
             // Extract the simple type name from the end
             var parts = fullTypeName.Split('.');
-            var simpleName = parts[^1]; // Last part
+            var simpleName = parts[parts.Length - 1]; // Last part
 
             // If the simple name is unique, use it
             if (!usedAliases.Contains(simpleName))
@@ -169,7 +178,7 @@ namespace TickerQ.SourceGenerator.Utilities
             // If not unique, try using just the parent namespace first (cleaner)
             if (parts.Length > 1)
             {
-                var parentName = parts[^2];
+                var parentName = parts[parts.Length - 2];
                 var parentAlias = $"{parentName}Alias";
                 if (!usedAliases.Contains(parentAlias))
                 {

--- a/src/TickerQ/TickerQ.csproj
+++ b/src/TickerQ/TickerQ.csproj
@@ -21,7 +21,7 @@
     </Target>
 
     <ItemGroup>
-        <None Include="..\TickerQ.SourceGenerator\bin\$(Configuration)\net9.0\TickerQ.SourceGenerator.dll"
+        <None Include="..\TickerQ.SourceGenerator\bin\$(Configuration)\netstandard2.0\TickerQ.SourceGenerator.dll"
               Pack="true"
               PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Targets the source generator to netstandard2.0 and updates code for C# 8/.NET Standard 2.0 compatibility; adjusts packaging to ship the netstandard2.0 analyzer and adds System.Memory.
> 
> - **Source Generator project**:
>   - Set `TargetFramework` to `netstandard2.0` and `LangVersion` to `8.0` in `src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj`.
>   - Add `System.Memory` dependency; keep Roslyn packages.
> - **Compatibility updates (C# 8/.NET Standard 2.0)**:
>   - Replace range/index operators and collection expressions with `Substring`, explicit indexes, and standard array/collection initializers.
>   - Convert switch expressions to classic `switch` statements.
>   - Return concrete `HashSet<string>` instead of spread syntax arrays.
>   - Use `SourceGeneratorConstants.FromKeyedServicesAttributeName` for attribute name checks.
> - **Utilities/Constants**:
>   - Add `FromKeyedServicesAttributeName` constant and expose common namespaces/variables as `HashSet<string>`/array.
>   - Add `NetStandardExtensions.Deconstruct` for `KeyValuePair` deconstruction.
> - **Packaging**:
>   - Update `src/TickerQ/TickerQ.csproj` to package analyzer from `netstandard2.0` output path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9135bf0a686ed521925f32b43ca8c4805b54c2e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->