### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
         <PackageTags>ticker;queue;cron;time;scheduler;fire-and-forget</PackageTags>
         <PackageIcon>icon.jpg</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>8.0.0-beta.14</Version>
+        <Version>8.0.0-beta.15</Version>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -187,7 +187,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         var now = _clock.UtcNow;
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         
-        await dbContext.Set<TimeTickerEntity>()
+        await dbContext.Set<TTimeTicker>()
             .WhereCanAcquire(instanceIdentifier)
             .ExecuteUpdateAsync(setter => setter
                 .SetProperty(x => x.LockHolder, _ => null)
@@ -196,7 +196,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
                 .SetProperty(x => x.UpdatedAt, now), cancellationToken)
             .ConfigureAwait(false);
         
-        await dbContext.Set<TimeTickerEntity>()
+        await dbContext.Set<TTimeTicker>()
             .Where(x => x.LockHolder == instanceIdentifier && x.Status == TickerStatus.InProgress)
             .ExecuteUpdateAsync(setter => setter
                 .SetProperty(x => x.Status, TickerStatus.Skipped)


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main
- ✅ Updated version numbers (9.0.x → 8.0.x for net8 branch)
- ✅ Updated target framework (net9.0 → net8.0 for net8 branch)
- ✅ Preserved .csproj files from net8 branch

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch EF DbSet to generic TTimeTicker in dead-node cleanup and bump package version to 8.0.0-beta.15.
> 
> - **Backend (EF Core)**:
>   - Replace `dbContext.Set<TimeTickerEntity>()` with `dbContext.Set<TTimeTicker>()` in `ReleaseDeadNodeTimeTickerResources`.
> - **Build/Packaging**:
>   - Bump `Version` to `8.0.0-beta.15` in `src/Directory.Build.props`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da86c416f16897235c9711c3f277f8e55c002204. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->