### PR TITLE
🔄 Sync main branch changes to net9

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
         <PackageTags>ticker;queue;cron;time;scheduler;fire-and-forget</PackageTags>
         <PackageIcon>icon.jpg</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>9.0.0-beta.15</Version>
+        <Version>9.0.0-beta.16</Version>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -121,7 +121,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await dbContext.Set<TTimeTicker>()
             .Where(x => x.Id == functionContexts.TickerId)
-            .ExecuteUpdateAsync(MappingExtensions.UpdateTimeTicker<TTimeTicker>(functionContexts, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
+            .ExecuteUpdateAsync(setter => setter.UpdateTimeTicker<TTimeTicker>(functionContexts, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
     }
         
     public async Task UpdateTimeTickersWithUnifiedContext(Guid[] timeTickerIds, InternalFunctionContext functionContext, CancellationToken cancellationToken = default)
@@ -129,7 +129,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<TTimeTicker>()
             .Where(x => timeTickerIds.Contains(x.Id))
-            .ExecuteUpdateAsync(MappingExtensions.UpdateTimeTicker<TTimeTicker>(functionContext, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
+            .ExecuteUpdateAsync(setter => setter.UpdateTimeTicker<TTimeTicker>(functionContext, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
     }
         
     public async Task<TimeTickerEntity[]> GetEarliestTimeTickers(CancellationToken cancellationToken)
@@ -266,7 +266,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>()
             .Where(x => x.Id == functionContext.TickerId)
-            .ExecuteUpdateAsync(MappingExtensions.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
+            .ExecuteUpdateAsync(setter => setter.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
             .ConfigureAwait(false);
     }
     
@@ -470,7 +470,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>()
             .Where(x => timeTickerIds.Contains(x.CronTickerId))
-            .ExecuteUpdateAsync(MappingExtensions.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
+            .ExecuteUpdateAsync(setter => setter.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
             .ConfigureAwait(false);
     }
     

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/TickerQueryExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/TickerQueryExtensions.cs
@@ -27,32 +27,3 @@ public static class TickerQueryExtensions
             );
     }
 }
-
-public static class ExpressionHelper
-{
-    public static Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> CombineSetters<T>(
-        Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> left,
-        Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> right)
-    {
-        var replacer = new ParameterReplacer(right.Parameters[0], left.Body);
-        var combined = replacer.Visit(right.Body);
-        return Expression.Lambda<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>>(combined, left.Parameters);
-    }
-}
-
-public class ParameterReplacer : ExpressionVisitor
-{
-    private readonly ParameterExpression _parameter;
-    private readonly Expression _replacement;
-
-    public ParameterReplacer(ParameterExpression parameter, Expression replacement)
-    {
-        _parameter = parameter;
-        _replacement = replacement;
-    }
-
-    protected override Expression VisitParameter(ParameterExpression node)
-    {
-        return node == _parameter ? _replacement : base.VisitParameter(node);
-    }
-}


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net9`.

### Changes Applied:
- ✅ Applied recent commits from main
- ✅ Updated version numbers (10.x.x → 9.x.x)
- ✅ Updated target framework (net10.0 → net9.0)
- ✅ Preserved .csproj files from net9 branch

### Review Notes:
- All .csproj files maintain net9 configurations
- Directory.Build.props has been updated for net9 compatibility
- Ready for testing on net9 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors EF Core update logic to fluent extension-based setters, updates all call sites, removes expression helper utilities, and bumps package version.
> 
> - **EntityFrameworkCore Infrastructure**:
>   - **Mapping**: Replace expression-returning update builders with fluent extension methods on `UpdateSettersBuilder` in `MappingExtensions` (`UpdateTimeTicker`, `UpdateCronTickerOccurrence`).
>   - **Call Sites**: Update `ExecuteUpdateAsync` usages in `BasePersistenceProvider` to `setter => setter.UpdateTimeTicker(...)` and `setter => setter.UpdateCronTickerOccurrence(...)`.
>   - **Projections**: Minor formatting/line-break updates to mapping lambdas (no functional changes indicated).
>   - **Cleanup**: Remove `ExpressionHelper` and `ParameterReplacer` from `TickerQueryExtensions` (no longer needed).
> - **Build**:
>   - Bump package `Version` in `src/Directory.Build.props` from `9.0.0-beta.15` to `9.0.0-beta.16`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 048f0dbf6860ccec3e995588e1a53767d349243a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->