### PR TITLE
🔄 Sync main branch changes to net9

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -121,7 +121,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await dbContext.Set<TTimeTicker>()
             .Where(x => x.Id == functionContexts.TickerId)
-            .ExecuteUpdateAsync(MappingExtensions.UpdateTimeTicker<TTimeTicker>(functionContexts, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
+            .ExecuteUpdateAsync(setter => setter.UpdateTimeTicker<TTimeTicker>(functionContexts, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
     }
         
     public async Task UpdateTimeTickersWithUnifiedContext(Guid[] timeTickerIds, InternalFunctionContext functionContext, CancellationToken cancellationToken = default)
@@ -129,7 +129,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<TTimeTicker>()
             .Where(x => timeTickerIds.Contains(x.Id))
-            .ExecuteUpdateAsync(MappingExtensions.UpdateTimeTicker<TTimeTicker>(functionContext, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
+            .ExecuteUpdateAsync(setter => setter.UpdateTimeTicker<TTimeTicker>(functionContext, _clock.UtcNow), cancellationToken).ConfigureAwait(false);
     }
         
     public async Task<TimeTickerEntity[]> GetEarliestTimeTickers(CancellationToken cancellationToken)
@@ -266,7 +266,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>()
             .Where(x => x.Id == functionContext.TickerId)
-            .ExecuteUpdateAsync(MappingExtensions.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
+            .ExecuteUpdateAsync(setter => setter.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
             .ConfigureAwait(false);
     }
     
@@ -470,7 +470,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>()
             .Where(x => timeTickerIds.Contains(x.CronTickerId))
-            .ExecuteUpdateAsync(MappingExtensions.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
+            .ExecuteUpdateAsync(setter => setter.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
             .ConfigureAwait(false);
     }
     

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/TickerQueryExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/TickerQueryExtensions.cs
@@ -27,32 +27,3 @@ public static class TickerQueryExtensions
             );
     }
 }
-
-public static class ExpressionHelper
-{
-    public static Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> CombineSetters<T>(
-        Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> left,
-        Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> right)
-    {
-        var replacer = new ParameterReplacer(right.Parameters[0], left.Body);
-        var combined = replacer.Visit(right.Body);
-        return Expression.Lambda<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>>(combined, left.Parameters);
-    }
-}
-
-public class ParameterReplacer : ExpressionVisitor
-{
-    private readonly ParameterExpression _parameter;
-    private readonly Expression _replacement;
-
-    public ParameterReplacer(ParameterExpression parameter, Expression replacement)
-    {
-        _parameter = parameter;
-        _replacement = replacement;
-    }
-
-    protected override Expression VisitParameter(ParameterExpression node)
-    {
-        return node == _parameter ? _replacement : base.VisitParameter(node);
-    }
-}


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net9`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 9.x.x)
- ✅ Updated target framework (net10.0 → net9.0)
- ✅ Preserved .csproj files from net9 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net9 configurations
- Directory.Build.props has been updated for net9 compatibility
- Ready for testing on net9 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors EF Core update helpers to fluent setter extension methods and updates call sites; removes unused expression-combining utilities.
> 
> - **EF Core Infrastructure**:
>   - Convert `MappingExtensions.UpdateTimeTicker` and `UpdateCronTickerOccurrence` from expression-returning helpers to `UpdateSettersBuilder` extension methods encapsulating property updates (incl. `UpdatedAt`).
>   - Update call sites in `BasePersistenceProvider` to use `ExecuteUpdateAsync(setter => setter.UpdateTimeTicker/UpdateCronTickerOccurrence(...))`.
>   - Remove obsolete `ExpressionHelper` and `ParameterReplacer` utilities from `TickerQueryExtensions`.
>   - Minor signature/formatting adjustments in mapping expressions (no behavior noted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d0de24e93997cf65a6fb1e0a8b39b2a8b8c5dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->