### PR TITLE
Fixed the json options to be isolated

### DIFF
--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace TickerQ.Dashboard.DependencyInjection
                 config.DashboardJsonOptions = new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     Converters = { new StringToByteArrayConverter() }
                 };
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes API responses to use dashboard-specific JSON options and sets default camelCase naming, ensuring required converters are included.
> 
> - **Backend/API**:
>   - **JSON serialization**: Switch many endpoints to `Results.Json(..., dashboardOptions.DashboardJsonOptions)` for consistent dashboard-specific serialization (auth, options, time tickers, cron tickers, statuses, functions, next ticker, delete/update/add operations).
>   - **Signatures**: Update numerous handlers to accept `DashboardOptionsBuilder`.
>   - **Default JSON options**: Set `PropertyNamingPolicy = JsonNamingPolicy.CamelCase` and always include `StringToByteArrayConverter` in `DashboardJsonOptions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ef5fc557cbf60380b98d395551dc4552a86c373. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->