### PR TITLE
🔄 Sync main branch changes to net9

### DIFF
--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace TickerQ.Dashboard.DependencyInjection
                 config.DashboardJsonOptions = new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     Converters = { new StringToByteArrayConverter() }
                 };
             }


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net9`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 9.x.x)
- ✅ Updated target framework (net10.0 → net9.0)
- ✅ Preserved .csproj files from net9 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net9 configurations
- Directory.Build.props has been updated for net9 compatibility
- Ready for testing on net9 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply dashboard-scoped JSON options (camelCase + converters) and switch endpoints to Results.Json with injected DashboardOptionsBuilder.
> 
> - **Backend / Dashboard**:
>   - **JSON Standardization**:
>     - Default `DashboardJsonOptions` now set (adds `PropertyNamingPolicy = CamelCase` and ensures `StringToByteArrayConverter`).
>     - Most endpoint handlers now return `Results.Json(..., dashboardOptions.DashboardJsonOptions)` instead of `Results.Ok`.
>     - Handlers updated to accept `DashboardOptionsBuilder` for consistent serialization.
>   - **Auth/Options Endpoints**:
>     - `GetAuthInfo`, `ValidateAuth`, and `GetOptions` now serialized via dashboard JSON options.
>   - **Tickers APIs**:
>     - Time/Cron ticker list, pagination, graph data, CRUD, occurrences, and metadata endpoints updated to standardized JSON responses.
>   - **Host/Stats**:
>     - `GetNextTicker`, job status, and machine jobs endpoints now use standardized JSON responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c34c10e3ffdb91d7d064a5186473ae868a2d3499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->