### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace TickerQ.Dashboard.DependencyInjection
                 config.DashboardJsonOptions = new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     Converters = { new StringToByteArrayConverter() }
                 };
             }


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 8.x.x)
- ✅ Updated target framework (net10.0 → net8.0)
- ✅ Preserved .csproj files from net8 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies API JSON responses using dashboard-configured JsonSerializerOptions (camelCase) and switches endpoints to Results.Json.
> 
> - **API/Endpoints**:
>   - Use `Results.Json(..., dashboardOptions.DashboardJsonOptions)` instead of `Results.Ok` across handlers (e.g., `GetAuthInfo`, `ValidateAuth`, `GetOptions`, ticker/cron endpoints, stats endpoints).
>   - Add `DashboardOptionsBuilder dashboardOptions` parameter to handlers to supply serialization options.
> - **Configuration**:
>   - Set default `DashboardJsonOptions` with `PropertyNamingPolicy = JsonNamingPolicy.CamelCase` and ensure `StringToByteArrayConverter` is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b19f41004d8e99f895cf6f4a93fab21acedd2a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->