### PR TITLE
🔄 Sync main branch changes to net9

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -339,7 +339,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
             ? dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>() 
             : dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>().Where(x => occurrenceIds.Contains(x.Id));
            
-        await baseQuery.Where(x => occurrenceIds.Contains(x.Id))
+        await baseQuery
             .WhereCanAcquire(_lockHolder)
             .ExecuteUpdateAsync(setter => setter
                 .SetProperty(x => x.LockHolder, _ => null)
@@ -415,7 +415,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
                 {
                     Id = item.NextCronOccurrence.Id,
                     CronTickerId = item.Id,
-                    ExecutionTime = now,
+                    ExecutionTime = executionTime,
                     Status = TickerStatus.Queued,
                     LockHolder = _lockHolder,
                     LockedAt = now,
@@ -464,13 +464,18 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
             .ConfigureAwait(false);
     }
     
-    public async Task UpdateCronTickerOccurrencesWithUnifiedContext(Guid[] timeTickerIds, InternalFunctionContext functionContext,
+    public async Task UpdateCronTickerOccurrencesWithUnifiedContext(Guid[] cronOccurrenceIds, InternalFunctionContext functionContext,
         CancellationToken cancellationToken = default)
     {
         await using var dbContext = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);;
         await dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>()
+<<<<<<< HEAD
             .Where(x => timeTickerIds.Contains(x.CronTickerId))
             .ExecuteUpdateAsync(MappingExtensions.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
+=======
+            .Where(x => cronOccurrenceIds.Contains(x.Id))
+            .ExecuteUpdateAsync(setter => setter.UpdateCronTickerOccurrence<TCronTicker>(functionContext), cancellationToken)
+>>>>>>> f7b961a (Fix/schedulerbackground (#376))
             .ConfigureAwait(false);
     }
     

--- a/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
+++ b/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
@@ -28,132 +28,99 @@ namespace TickerQ.Utilities.Managers
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _notificationHubSender = notificationHubSender;
         }
-
+        
         public async Task<(TimeSpan TimeRemaining, InternalFunctionContext[] Functions)> GetNextTickers(CancellationToken cancellationToken = default)
-        {
-            while (true)
-            {
-                var minCronGroupTask =  GetEarliestCronTickerGroupAsync(cancellationToken);
-                var minTimeTickersTask =  _persistenceProvider.GetEarliestTimeTickers(cancellationToken);
-                
-                await Task.WhenAll(minCronGroupTask, minTimeTickersTask).ConfigureAwait(false);
-                
-                var (minCronGroup, minTimeTickers) = (await minCronGroupTask, await minTimeTickersTask);
-                
-                var minTimeTickerTime = minTimeTickers.Length != 0
-                    ? minTimeTickers[0].ExecutionTime ?? default
-                    : default;
-
-                var minTimeRemaining = CalculateMinTimeRemaining(minCronGroup, minTimeTickerTime, out var typesToQueue);
-
-                if (minTimeRemaining == Timeout.InfiniteTimeSpan) 
-                    return (Timeout.InfiniteTimeSpan, []);
-
-                var nextTickers = await RetrieveEligibleTickersAsync(minCronGroup, minTimeTickers, typesToQueue, cancellationToken).ConfigureAwait(false);
-
-                if (nextTickers.Length != 0) 
-                    return (minTimeRemaining, nextTickers);
-                
-                if(typesToQueue.All(x => x == TickerType.CronTickerOccurrence))
-                    return (minTimeRemaining, nextTickers);
-                
-                await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken).ConfigureAwait(false);  // Faster retry for time-sensitive tasks
-            }
-        }
-
-        private TimeSpan CalculateMinTimeRemaining(
-            (DateTime Key, InternalManagerContext[] Items)? minCronTicker,
-            DateTime minTimeTicker,
-            out TickerType[] sources)
         {
             var now = _clock.UtcNow;
 
-            DateTime? cron = minCronTicker?.Key;
-            DateTime? time = minTimeTicker == default ? null : minTimeTicker;
+            var minCronGroupTask = GetEarliestCronTickerGroupAsync(cancellationToken);
+            var minTimeTickersTask = _persistenceProvider.GetEarliestTimeTickers(cancellationToken);
 
-            // no values
-            if (cron is null && time is null)
+            await Task.WhenAll(minCronGroupTask, minTimeTickersTask).ConfigureAwait(false);
+
+            var minCronGroup = await minCronGroupTask.ConfigureAwait(false);
+            var minTimeTickers = await minTimeTickersTask.ConfigureAwait(false);
+
+            var cronTime = minCronGroup?.Key;
+            var timeTickerTime = minTimeTickers.Length > 0
+                ? minTimeTickers[0].ExecutionTime
+                : null;
+
+            if (cronTime is null && timeTickerTime is null)
+                return (Timeout.InfiniteTimeSpan, []);
+
+            TimeSpan timeRemaining;
+            bool includeCron = false;
+            bool includeTimeTickers = false;
+
+            if (cronTime is null)
             {
-                sources = [];
-                return Timeout.InfiniteTimeSpan;
+                includeTimeTickers = true;
+                timeRemaining = SafeRemaining(timeTickerTime!.Value, now);
+            }
+            else if (timeTickerTime is null)
+            {
+                includeCron = true;
+                timeRemaining = SafeRemaining(cronTime.Value, now);
+            }
+            else
+            {
+                var cronSecond = new DateTime(cronTime.Value.Year, cronTime.Value.Month, cronTime.Value.Day,
+                    cronTime.Value.Hour, cronTime.Value.Minute, cronTime.Value.Second);
+                var timeSecond = new DateTime(timeTickerTime.Value.Year, timeTickerTime.Value.Month, timeTickerTime.Value.Day,
+                    timeTickerTime.Value.Hour, timeTickerTime.Value.Minute, timeTickerTime.Value.Second);
+
+                if (cronSecond == timeSecond)
+                {
+                    includeCron = true;
+                    includeTimeTickers = true;
+                    var earliest = cronTime < timeTickerTime ? cronTime.Value : timeTickerTime.Value;
+                    timeRemaining = SafeRemaining(earliest, now);
+                }
+                else if (cronTime < timeTickerTime)
+                {
+                    includeCron = true;
+                    timeRemaining = SafeRemaining(cronTime.Value, now);
+                }
+                else
+                {
+                    includeTimeTickers = true;
+                    timeRemaining = SafeRemaining(timeTickerTime.Value, now);
+                }
             }
 
-            // only cron
-            if (time is null)
-            {
-                sources = [TickerType.CronTickerOccurrence];
-                var cronRemaining = cron.Value - now;
-                // Ensure we don't return negative values - schedule for immediate execution
-                return cronRemaining < TimeSpan.Zero ? TimeSpan.Zero : cronRemaining;
-            }
+            if (!includeCron && !includeTimeTickers)
+                return (Timeout.InfiniteTimeSpan, []);
 
-            // only time
-            if (cron is null)
-            {
-                sources = [TickerType.TimeTicker];
-                var timeRemaining = time.Value - now;
-                // Ensure we don't return negative values - schedule for immediate execution
-                return timeRemaining < TimeSpan.Zero ? TimeSpan.Zero : timeRemaining;
-            }
+            InternalFunctionContext[] cronFunctions = [];
+            InternalFunctionContext[] timeFunctions = [];
 
-            // both present - check if they're in the exact same second (ignoring milliseconds)
-            var cronSecond = new DateTime(cron.Value.Year, cron.Value.Month, cron.Value.Day, 
-                                          cron.Value.Hour, cron.Value.Minute, cron.Value.Second);
-            var timeSecond = new DateTime(time.Value.Year, time.Value.Month, time.Value.Day,
-                                          time.Value.Hour, time.Value.Minute, time.Value.Second);
-            
-            // Only batch if they're in the exact same second
-            if (cronSecond == timeSecond)
-            {
-                sources = [TickerType.CronTickerOccurrence, TickerType.TimeTicker];
-                var earliest = cron < time ? cron.Value : time.Value;
-                var earliestRemaining = earliest - now;
-                // Ensure we don't return negative values
-                return earliestRemaining < TimeSpan.Zero ? TimeSpan.Zero : earliestRemaining;
-            }
+            if (includeCron && minCronGroup is not null)
+                cronFunctions = await QueueNextCronTickersAsync(minCronGroup.Value, cancellationToken).ConfigureAwait(false);
 
-            // Different seconds - only process the earliest one
-            if (cron < time)
-            {
-                sources = [TickerType.CronTickerOccurrence];
-                var cronRemaining = cron.Value - now;
-                return cronRemaining < TimeSpan.Zero ? TimeSpan.Zero : cronRemaining;
-            }
+            if (includeTimeTickers && minTimeTickers.Length > 0)
+                timeFunctions = await QueueNextTimeTickersAsync(minTimeTickers, cancellationToken).ConfigureAwait(false);
 
-            sources = [TickerType.TimeTicker];
-            var finalTimeRemaining = time.Value - now;
-            return finalTimeRemaining < TimeSpan.Zero ? TimeSpan.Zero : finalTimeRemaining;
+            if (cronFunctions.Length == 0 && timeFunctions.Length == 0)
+                return (timeRemaining, []);
+
+            if (cronFunctions.Length == 0)
+                return (timeRemaining, timeFunctions);
+
+            if (timeFunctions.Length == 0)
+                return (timeRemaining, cronFunctions);
+
+            var merged = new InternalFunctionContext[cronFunctions.Length + timeFunctions.Length];
+            cronFunctions.AsSpan().CopyTo(merged.AsSpan(0, cronFunctions.Length));
+            timeFunctions.AsSpan().CopyTo(merged.AsSpan(cronFunctions.Length, timeFunctions.Length));
+
+            return (timeRemaining, merged);
         }
 
-        private async Task<InternalFunctionContext[]>RetrieveEligibleTickersAsync(
-            (DateTime Key, InternalManagerContext[] Items)? minCronTicker,
-            TimeTickerEntity[] minTimeTicker,
-            TickerType[] typesToQueue,
-            CancellationToken cancellationToken = default)
+        private static TimeSpan SafeRemaining(DateTime target, DateTime now)
         {
-            
-            if (typesToQueue.Contains(TickerType.CronTickerOccurrence) && typesToQueue.Contains(TickerType.TimeTicker))
-            {
-                var nextCronTickersTask = QueueNextCronTickersAsync(minCronTicker!.Value, cancellationToken);
-                var nextTimeTickersTask = QueueNextTimeTickersAsync(minTimeTicker, cancellationToken);
-
-                await Task.WhenAll(nextCronTickersTask, nextTimeTickersTask).ConfigureAwait(false);
-                
-                var (nextCronTickers, nextTimeTickers) = (await nextCronTickersTask, await nextTimeTickersTask);
-                
-                // Safety check for extremely large datasets
-                var totalLength = nextCronTickers.Length + nextTimeTickers.Length;
-                
-                var merged = new InternalFunctionContext[totalLength];
-                nextCronTickers.AsSpan().CopyTo(merged.AsSpan(0, nextCronTickers.Length));
-                nextTimeTickers.AsSpan().CopyTo(merged.AsSpan(nextCronTickers.Length, nextTimeTickers.Length));
-                return merged;
-            }
-
-            if (typesToQueue.Contains(TickerType.TimeTicker))
-                return await QueueNextTimeTickersAsync(minTimeTicker, cancellationToken).ConfigureAwait(false);
-            else
-                return await QueueNextCronTickersAsync(minCronTicker!.Value, cancellationToken).ConfigureAwait(false);
+            var remaining = target - now;
+            return remaining < TimeSpan.Zero ? TimeSpan.Zero : remaining;
         }
 
         private async Task<InternalFunctionContext[]> QueueNextTimeTickersAsync(TimeTickerEntity[] minTimeTickers, CancellationToken cancellationToken = default)
@@ -489,9 +456,9 @@ namespace TickerQ.Utilities.Managers
         public async Task DeleteTicker(Guid tickerId, TickerType type, CancellationToken cancellationToken = default)
         {
             if (type == TickerType.CronTickerOccurrence)
-               await _persistenceProvider.RemoveTimeTickers([tickerId], cancellationToken).ConfigureAwait(false);
-            else
                 await _persistenceProvider.RemoveCronTickers([tickerId], cancellationToken).ConfigureAwait(false);
+            else
+                await _persistenceProvider.RemoveTimeTickers([tickerId], cancellationToken).ConfigureAwait(false);
         }
 
         public async Task ReleaseDeadNodeResources(string instanceIdentifier, CancellationToken cancellationToken = default)

--- a/src/TickerQ.Utilities/Models/InternalFunctionContext.cs
+++ b/src/TickerQ.Utilities/Models/InternalFunctionContext.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using TickerQ.Utilities.Enums;

--- a/src/TickerQ/Src/TickerQThreadPool/WorkItem.cs
+++ b/src/TickerQ/Src/TickerQThreadPool/WorkItem.cs
@@ -18,3 +18,4 @@ public readonly struct WorkItem
         UserToken = userToken;
     }
 }
+


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net9`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 9.x.x)
- ✅ Updated target framework (net10.0 → net9.0)
- ✅ Preserved .csproj files from net9 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net9 configurations
- Directory.Build.props has been updated for net9 compatibility
- Ready for testing on net9 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace scheduler timers with Task.Delay loops, refine next-ticker batching/selection, correct cron occurrence updates and execution times, and fix deletion routing.
> 
> - **Scheduler/Background Services**:
>   - Replace `PeriodicTimer` loops with `while` + `Task.Delay`, using dynamic sleep durations and clearing execution context safely.
>   - Adjust restart logic to trigger only when a new task is overdue or ≥500ms earlier than planned.
> - **Ticker selection/queuing**:
>   - Rewrite `GetNextTickers` to compute remaining time once, batch cron/time tickers when in the same second, and merge queued functions.
>   - Add `SafeRemaining` helper for non-negative delays.
> - **Persistence (EF Core)**:
>   - `ReleaseAcquiredCronTickerOccurrences`: simplify to use `baseQuery` directly.
>   - `QueueCronTickerOccurrences`: set `ExecutionTime` from the group key (`executionTime`) instead of `now`.
>   - `UpdateCronTickerOccurrencesWithUnifiedContext`: update by occurrence IDs (`cronOccurrenceIds`) via `setter.UpdateCronTickerOccurrence`.
> - **Other**:
>   - Fix `DeleteTicker` routing for cron vs time tickers.
>   - Minor cleanup in `InternalFunctionContext` usings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98ac6ccc2c90c5eabc3ed0a8c0955c27fb56a9fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->