### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,20 @@ dotnet add package TickerQ.Dashboard
 ```csharp
 builder.Services.AddTickerQ(options =>
 {
-    opt.SetMaxConcurrency(10);
+    options.ConfigureScheduler(scheduler =>
+    {
+        scheduler.MaxConcurrency = 10;
+    });
+
     options.AddOperationalStore<MyDbContext>(efOpt => 
     {
         efOpt.SetExceptionHandler<MyExceptionHandlerClass>();
         efOpt.UseModelCustomizerForMigrations();
     });
-    options.AddDashboard(uiopt =>                                                
+    options.AddDashboard(dashboardOptions =>                                                
     {
-        uiopt.BasePath = "/tickerq-dashboard"; 
-        uiopt.AddDashboardBasicAuth();
+        dashboardOptions.SetBasePath("/tickerq/dashboard"); 
+        dashboardOptions.WithBasicAuth("admin", "secure-password");
     }
 });
 

--- a/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
+++ b/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
@@ -9,7 +9,7 @@ namespace TickerQ.Dashboard;
 
 public class DashboardOptionsBuilder
 {
-    internal string BasePath { get; set; } = "/";
+    internal string BasePath { get; set; } = "/tickerq/dashboard";
     internal Action<CorsPolicyBuilder> CorsPolicyBuilder { get; set; }
     internal string BackendDomain { get; set; }
     

--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -43,8 +43,6 @@ namespace TickerQ.Dashboard.DependencyInjection
             
             // Register the dashboard configuration for DI
             services.AddSingleton(config);
-            services.AddSingleton(config.Auth);
-            services.AddScoped<IAuthService, AuthService>();
             
             services.AddRouting();
             services.AddSignalR();

--- a/src/TickerQ.Dashboard/README.md
+++ b/src/TickerQ.Dashboard/README.md
@@ -26,13 +26,13 @@ services.AddTickerQ<MyTimeTicker, MyCronTicker>(config =>
 });
 ```
 
-### Bearer Token Authentication
+### API Key Authentication
 ```csharp
 services.AddTickerQ<MyTimeTicker, MyCronTicker>(config =>
 {
     config.AddDashboard(dashboard =>
     {
-        dashboard.WithBearerToken("my-secret-api-key-12345");
+        dashboard.WithApiKey("my-secret-api-key-12345");
     });
 });
 ```
@@ -43,9 +43,7 @@ services.AddTickerQ<MyTimeTicker, MyCronTicker>(config =>
 {
     config.AddDashboard(dashboard =>
     {
-        dashboard.WithHostAuthentication(
-            requiredRoles: new[] { "Admin", "TickerQUser" }
-        );
+        dashboard.WithHostAuthentication();
     });
 });
 ```
@@ -53,8 +51,8 @@ services.AddTickerQ<MyTimeTicker, MyCronTicker>(config =>
 ## 🔧 Fluent API Methods
 
 - `WithBasicAuth(username, password)` - Enable username/password authentication
-- `WithBearerToken(apiKey)` - Enable API key authentication  
-- `WithHostAuthentication(roles?, policies?)` - Use your app's existing auth
+- `WithApiKey(apiKey)` - Enable API key authentication  
+- `WithHostAuthentication()` - Use your app's existing auth
 - `SetBasePath(path)` - Set dashboard URL path
 - `SetBackendDomain(domain)` - Set backend API domain
 - `SetCorsPolicy(policy)` - Configure CORS

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerOccurrenceService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerOccurrenceService.ts
@@ -5,6 +5,7 @@ import { Status } from './types/base/baseHttpResponse.types';
 import { GetCronTickerOccurrenceGraphDataRequest, GetCronTickerOccurrenceGraphDataResponse, GetCronTickerOccurrenceRequest, GetCronTickerOccurrenceResponse } from './types/cronTickerOccurrenceService.types';
 import { format} from 'timeago.js';
 import { nameof } from '@/utilities/nameof';
+import { useTimeZoneStore } from '@/stores/timeZoneStore';
 
 interface PaginatedCronTickerOccurrenceResponse {
     items: GetCronTickerOccurrenceResponse[]
@@ -14,6 +15,7 @@ interface PaginatedCronTickerOccurrenceResponse {
 }
 
 const getByCronTickerId = () => {
+    const timeZoneStore = useTimeZoneStore();
     const baseHttp = useBaseHttpService<GetCronTickerOccurrenceRequest, GetCronTickerOccurrenceResponse>('array')
         .FixToResponseModel(GetCronTickerOccurrenceResponse, response => {
             if (!response) {
@@ -32,8 +34,8 @@ const getByCronTickerId = () => {
             }
 
             const utcExecutionTime = response.executionTime.endsWith('Z') ? response.executionTime : response.executionTime + 'Z';
-            response.executionTimeFormatted = formatDate(utcExecutionTime);
-            response.lockedAt = formatDate(response.lockedAt)
+            response.executionTimeFormatted = formatDate(utcExecutionTime, true, timeZoneStore.effectiveTimeZone);
+            response.lockedAt = formatDate(response.lockedAt, true, timeZoneStore.effectiveTimeZone)
             return response;
         })
         .FixToHeaders((header) => {
@@ -63,6 +65,7 @@ const getByCronTickerId = () => {
 }
 
 const getByCronTickerIdPaginated = () => {
+    const timeZoneStore = useTimeZoneStore();
     const baseHttp = useBaseHttpService<object, PaginatedCronTickerOccurrenceResponse>('single');
     
     const processResponse = (response: PaginatedCronTickerOccurrenceResponse): PaginatedCronTickerOccurrenceResponse => {
@@ -86,8 +89,8 @@ const getByCronTickerIdPaginated = () => {
                     }
                     
                     const utcExecutionTime = item.executionTime.endsWith('Z') ? item.executionTime : item.executionTime + 'Z';
-                    item.executionTimeFormatted = formatDate(utcExecutionTime);
-                    item.lockedAt = formatDate(item.lockedAt);
+                    item.executionTimeFormatted = formatDate(utcExecutionTime, true, timeZoneStore.effectiveTimeZone);
+                    item.lockedAt = formatDate(item.lockedAt, true, timeZoneStore.effectiveTimeZone);
                     
                     return item;
                 });
@@ -126,11 +129,12 @@ const deleteCronTickerOccurrence = () => {
 }
 
 const getCronTickerOccurrenceGraphData = () => {
+    const timeZoneStore = useTimeZoneStore();
     const baseHttp = useBaseHttpService<GetCronTickerOccurrenceGraphDataRequest, GetCronTickerOccurrenceGraphDataResponse>('array')
         .FixToResponseModel(GetCronTickerOccurrenceGraphDataResponse, (item) => {
             return {
                 ...item,
-                date: formatDate(item.date),
+                date: formatDate(item.date, false, timeZoneStore.effectiveTimeZone),
                 type: "line",
                 statuses: item.results.map(x => Status[x.item1])
             }

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
@@ -4,6 +4,7 @@ import { useBaseHttpService } from '../base/baseHttpService';
 import { AddCronTickerRequest, GetCronTickerGraphDataRangeResponse, GetCronTickerGraphDataResponse, GetCronTickerRequest, GetCronTickerResponse, UpdateCronTickerRequest } from './types/cronTickerService.types';
 import { nameof } from '@/utilities/nameof';
 import { useFunctionNameStore } from '@/stores/functionNames';
+import { useTimeZoneStore } from '@/stores/timeZoneStore';
 
 interface PaginatedCronTickerResponse {
     items: GetCronTickerResponse[]
@@ -14,12 +15,13 @@ interface PaginatedCronTickerResponse {
 
 const getCronTickers = () => {
     const functionNamesStore = useFunctionNameStore();
+    const timeZoneStore = useTimeZoneStore();
 
     const baseHttp = useBaseHttpService<GetCronTickerRequest, GetCronTickerResponse>('array')
         .FixToResponseModel(GetCronTickerResponse, response => {
             response.requestType = functionNamesStore.getNamespaceOrNull(response.function) ?? 'N/A';
-            response.createdAt = formatDate(response.createdAt);
-            response.updatedAt = formatDate(response.updatedAt);
+            response.createdAt = formatDate(response.createdAt, true, timeZoneStore.effectiveTimeZone);
+            response.updatedAt = formatDate(response.updatedAt, true, timeZoneStore.effectiveTimeZone);
             response.initIdentifier = response.initIdentifier?.split("_").slice(0, 2).join("_");
             if ((response.retryIntervals == null || response.retryIntervals.length == 0) && (response.retries == null || (response.retries as number) == 0))
                 response.retryIntervals = [];
@@ -50,6 +52,7 @@ const getCronTickers = () => {
 
 const getCronTickersPaginated = () => {
     const functionNamesStore = useFunctionNameStore();
+    const timeZoneStore = useTimeZoneStore();
     
     const baseHttp = useBaseHttpService<object, PaginatedCronTickerResponse>('single');
     
@@ -58,8 +61,8 @@ const getCronTickersPaginated = () => {
             if (response && response.items && Array.isArray(response.items)) {
                 response.items = response.items.map((item: GetCronTickerResponse) => {
                     item.requestType = functionNamesStore.getNamespaceOrNull(item.function) ?? 'N/A';
-                    item.createdAt = formatDate(item.createdAt);
-                    item.updatedAt = formatDate(item.updatedAt);
+                    item.createdAt = formatDate(item.createdAt, true, timeZoneStore.effectiveTimeZone);
+                    item.updatedAt = formatDate(item.updatedAt, true, timeZoneStore.effectiveTimeZone);
                     item.initIdentifier = item.initIdentifier?.split("_").slice(0, 2).join("_");
                     if ((item.retryIntervals == null || item.retryIntervals.length == 0) && (item.retries == null || (item.retries as number) == 0))
                         item.retryIntervals = [];
@@ -184,4 +187,3 @@ export const cronTickerService = {
     getTimeTickersGraphDataRangeById,
     getTimeTickersGraphData
 };
-

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/types/tickerService.types.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/types/tickerService.types.ts
@@ -40,6 +40,7 @@ export class GetOptions{
     maxConcurrency!:number;
     currentMachine!:string;
     lastHostExceptionMessage!:string;
+    schedulerTimeZone?:string;
 }
 
 export class GetMachineJobs{

--- a/src/TickerQ.Dashboard/wwwroot/src/hub/base/baseHub.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/hub/base/baseHub.ts
@@ -52,7 +52,10 @@ class BaseHub {
         if (backendUrl) {
             hubUrl = `${backendUrl}/ticker-notification-hub`;
         } else {
-            hubUrl = `${basePath}/ticker-notification-hub`;
+            // Avoid leading '//' when basePath is '/'
+            hubUrl = basePath === '/' 
+                ? '/ticker-notification-hub' 
+                : `${basePath}/ticker-notification-hub`;
         }
 
         const authInfo = getAuthInfo();

--- a/src/TickerQ.Dashboard/wwwroot/src/stores/timeZoneStore.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/stores/timeZoneStore.ts
@@ -1,0 +1,90 @@
+import { defineStore } from 'pinia'
+import { ref, computed, watch } from 'vue'
+
+export const useTimeZoneStore = defineStore('timeZone', () => {
+  const STORAGE_KEY = 'tickerq:dashboard:timezone'
+
+  const schedulerTimeZone = ref<string | null>(null)
+  const selectedTimeZone = ref<string | null>(null)
+
+  // A small curated list of common IANA time zones.
+  // The scheduler's configured time zone will be added dynamically if it's not in this list.
+  const commonTimeZones = ref<string[]>([
+    'UTC',
+    'Europe/London',
+    'Europe/Berlin',
+    'America/New_York',
+    'America/Chicago',
+    'America/Denver',
+    'America/Los_Angeles',
+    'Asia/Tokyo',
+    'Asia/Singapore',
+    'Australia/Sydney'
+  ])
+
+  const availableTimeZones = computed(() => {
+    const zones = new Set(commonTimeZones.value)
+
+    if (schedulerTimeZone.value) {
+      zones.add(schedulerTimeZone.value)
+    }
+
+    // Browser local time zone (if available)
+    try {
+      const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone
+      if (browserTz) {
+        zones.add(browserTz)
+      }
+    } catch {
+      // ignore
+    }
+
+    return Array.from(zones)
+  })
+
+  const effectiveTimeZone = computed(() => {
+    return selectedTimeZone.value || schedulerTimeZone.value || 'UTC'
+  })
+
+  // Initialize from localStorage (if available)
+  if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      selectedTimeZone.value = stored
+    }
+  }
+
+  function setSchedulerTimeZone(id: string | null | undefined) {
+    schedulerTimeZone.value = id || null
+  }
+
+  function setSelectedTimeZone(id: string | null) {
+    selectedTimeZone.value = id
+  }
+
+  // Persist user selection to localStorage
+  watch(
+    selectedTimeZone,
+    (val) => {
+      if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+        return
+      }
+
+      if (val) {
+        window.localStorage.setItem(STORAGE_KEY, val)
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY)
+      }
+    },
+    { immediate: false }
+  )
+
+  return {
+    schedulerTimeZone,
+    selectedTimeZone,
+    availableTimeZones,
+    effectiveTimeZone,
+    setSchedulerTimeZone,
+    setSelectedTimeZone
+  }
+})

--- a/src/TickerQ.Dashboard/wwwroot/src/views/Dashboard.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/Dashboard.vue
@@ -5,6 +5,7 @@ import { computed, onMounted, onUnmounted, ref, watch, type Ref } from 'vue'
 import TickerNotificationHub, { methodName } from '@/hub/tickerNotificationHub'
 import { useFunctionNameStore } from '@/stores/functionNames'
 import { useDashboardStore } from '@/stores/dashboardStore'
+import { useTimeZoneStore } from '@/stores/timeZoneStore'
 import { Status } from '@/http/services/types/base/baseHttpResponse.types'
 
 const getNextPlannedTicker = tickerService.getNextPlannedTicker()
@@ -14,6 +15,7 @@ const getJobStatusesPastWeek = tickerService.getJobStatusesPastWeek()
 const getJobStatusesOverall = tickerService.getJobStatusesOverall()
 const functionNamesStore = useFunctionNameStore()
 const dashboardStore = useDashboardStore()
+const timeZoneStore = useTimeZoneStore()
 
 const activeThreads = ref(0)
 
@@ -24,6 +26,10 @@ onMounted(async () => {
     dashboardStore.setNextOccurrence(getNextPlannedTicker.response.value.nextOccurrence)
   }
   await getOptions.requestAsync()
+
+  if (getOptions.response.value?.schedulerTimeZone) {
+    timeZoneStore.setSchedulerTimeZone(getOptions.response.value.schedulerTimeZone)
+  }
   await getJobStatusesOverall.requestAsync().then((res) => {
     const total = res.reduce((sum, item) => sum + item.item2, 0)
 
@@ -247,7 +253,7 @@ const getVisiblePageNumbers = () => {
                 dashboardStore.displayNextOccurrence === 'Not Scheduled' ||
                 dashboardStore.displayNextOccurrence == undefined
                   ? 'Not Scheduled'
-                  : formatDate(dashboardStore.displayNextOccurrence)
+                  : formatDate(dashboardStore.displayNextOccurrence, true, timeZoneStore.effectiveTimeZone)
               }}
             </p>
             <div v-else class="skeleton-text metric-value-skeleton"></div>

--- a/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
+++ b/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
@@ -13,36 +13,9 @@ namespace TickerQ.EntityFrameworkCore
         where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
         where TCronTicker : CronTickerEntity, new()
     {
-        internal bool SeedDefinedCronTickers { get; private set; } = true;
-        internal Func<ITimeTickerManager<TTimeTicker>, Task> TimeSeeder { get; private set; }
-        internal Func<ICronTickerManager<TCronTicker>, Task> CronSeeder  { get; private set; }
         internal Action<IServiceCollection> ConfigureServices { get; set; }
         internal int PoolSize { get; set; } = 1024;
         internal string Schema { get; set; } = "ticker";
-        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> IgnoreSeedDefinedCronTickers()
-        {
-            SeedDefinedCronTickers = false;
-            return this;
-        }
-
-        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(Func<ITimeTickerManager<TTimeTicker>, Task> timeTickerAsync)
-        {
-            TimeSeeder = async t => await timeTickerAsync(t);
-            return this;
-        }
-
-        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(Func<ICronTickerManager<TCronTicker>, Task> cronTickerAsync)
-        {
-            CronSeeder = async c => await cronTickerAsync(c);
-            return this;
-        }
-
-        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(Func<ITimeTickerManager<TTimeTicker>, Task> timeTickerAsync, Func<ICronTickerManager<TCronTicker>, Task> cronTickerAsync)
-        {
-            TimeSeeder = async t => await timeTickerAsync(t);
-            CronSeeder = async c => await cronTickerAsync(c);
-            return this;
-        }
 
         public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseApplicationDbContext<TDbContext>(ConfigurationType configurationType) where TDbContext : DbContext
         {

--- a/src/TickerQ.Utilities/Base/TickerFunctionContext.cs
+++ b/src/TickerQ.Utilities/Base/TickerFunctionContext.cs
@@ -13,7 +13,7 @@ public class TickerFunctionContext<TRequest> : TickerFunctionContext
         Type = tickerFunctionContext.Type;
         RetryCount = tickerFunctionContext.RetryCount;
         IsDue = tickerFunctionContext.IsDue;
-        CancelOperationAction = tickerFunctionContext.CancelOperationAction;
+        RequestCancelOperationAction = tickerFunctionContext.RequestCancelOperationAction;
         CronOccurrenceOperations = tickerFunctionContext.CronOccurrenceOperations;
         FunctionName = tickerFunctionContext.FunctionName;
     }
@@ -24,15 +24,15 @@ public class TickerFunctionContext<TRequest> : TickerFunctionContext
 public class TickerFunctionContext
 {
     internal AsyncServiceScope ServiceScope { get; set; }
-    internal Action CancelOperationAction { get; set; }
+    internal Action RequestCancelOperationAction { get; set; }
     public Guid Id { get; internal set; }
     public TickerType Type { get; internal set; }
     public int RetryCount { get; internal set; }
     public bool IsDue { get; internal set; }
     public string FunctionName { get; internal set; }
     public CronOccurrenceOperations CronOccurrenceOperations { get; internal set; }
-    public void CancelOperation() 
-        => CancelOperationAction();
+    public void RequestCancellation() 
+        => RequestCancelOperationAction();
     internal void SetServiceScope(AsyncServiceScope serviceScope)
         => ServiceScope = serviceScope;
 }

--- a/src/TickerQ.Utilities/TickerExecutionContext.cs
+++ b/src/TickerQ.Utilities/TickerExecutionContext.cs
@@ -2,10 +2,18 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using TickerQ.Utilities.Enums;
 using TickerQ.Utilities.Models;
 
 namespace TickerQ.Utilities;
+
+internal interface ITickerOptionsSeeding
+{
+    bool SeedDefinedCronTickers { get; }
+    Func<IServiceProvider, System.Threading.Tasks.Task> TimeSeederAction { get; }
+    Func<IServiceProvider, System.Threading.Tasks.Task> CronSeederAction { get; }
+}
 
 internal class TickerExecutionContext
 {
@@ -14,6 +22,7 @@ internal class TickerExecutionContext
    internal Action<IApplicationBuilder> DashboardApplicationAction { get; set; }
    public Action<object, CoreNotifyActionType> NotifyCoreAction { get; set; }
    public string LastHostExceptionMessage { get; set; }
+   internal ITickerOptionsSeeding OptionsSeeding { get; set; }
    
    internal volatile InternalFunctionContext[] Functions = [];
    

--- a/src/TickerQ.Utilities/TickerOptionsBuilder.cs
+++ b/src/TickerQ.Utilities/TickerOptionsBuilder.cs
@@ -4,10 +4,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Interfaces;
+using TickerQ.Utilities.Interfaces.Managers;
 
 namespace TickerQ.Utilities
 {
-    public class TickerOptionsBuilder<TTimeTicker, TCronTicker>
+    public class TickerOptionsBuilder<TTimeTicker, TCronTicker> : ITickerOptionsSeeding
         where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
         where TCronTicker : CronTickerEntity, new()
     {
@@ -18,7 +19,36 @@ namespace TickerQ.Utilities
         {
             _tickerExecutionContext = tickerExecutionContext;
             _schedulerOptions = schedulerOptions;
+            // Store this instance in the execution context for later retrieval
+            tickerExecutionContext.OptionsSeeding = this;
         }
+
+        /// <summary>
+        /// Internal flag for request GZip compression.
+        /// Defaults to false (plain JSON bytes).
+        /// </summary>
+        internal bool RequestGZipCompressionEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Controls whether code-defined cron tickers are seeded on startup.
+        /// Defaults to true.
+        /// </summary>
+        internal bool SeedDefinedCronTickers { get; set; } = true;
+
+        /// <summary>
+        /// Seeding delegate for time tickers, executed with the application's service provider.
+        /// </summary>
+        internal Func<IServiceProvider, System.Threading.Tasks.Task> TimeSeederAction { get; set; }
+
+        /// <summary>
+        /// Seeding delegate for cron tickers, executed with the application's service provider.
+        /// </summary>
+        internal Func<IServiceProvider, System.Threading.Tasks.Task> CronSeederAction { get; set; }
+
+        // Explicit interface implementation for ITickerOptionsSeeding
+        bool ITickerOptionsSeeding.SeedDefinedCronTickers => SeedDefinedCronTickers;
+        Func<IServiceProvider, System.Threading.Tasks.Task> ITickerOptionsSeeding.TimeSeederAction => TimeSeederAction;
+        Func<IServiceProvider, System.Threading.Tasks.Task> ITickerOptionsSeeding.CronSeederAction => CronSeederAction;
 
         internal Action<IServiceCollection> ExternalProviderConfigServiceAction { get; set; }
         internal Action<IServiceCollection> DashboardServiceAction { get; set; }
@@ -46,6 +76,72 @@ namespace TickerQ.Utilities
         {
             RequestJsonSerializerOptions ??= new JsonSerializerOptions();
             configure?.Invoke(RequestJsonSerializerOptions);
+            return this;
+        }
+
+        /// <summary>
+        /// Enables GZip compression for ticker request payloads.
+        /// When not called, requests are stored as plain UTF-8 JSON bytes.
+        /// </summary>
+        /// <returns>The TickerOptionsBuilder for method chaining</returns>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> UseGZipCompression()
+        {
+            RequestGZipCompressionEnabled = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Disable automatic seeding of code-defined cron tickers on startup.
+        /// </summary>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> IgnoreSeedDefinedCronTickers()
+        {
+            SeedDefinedCronTickers = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Configure a custom seeder for time tickers, executed on application startup.
+        /// </summary>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(
+            Func<ITimeTickerManager<TTimeTicker>, System.Threading.Tasks.Task> timeSeeder)
+        {
+            if (timeSeeder == null) return this;
+
+            TimeSeederAction = async sp =>
+            {
+                var manager = sp.GetRequiredService<ITimeTickerManager<TTimeTicker>>();
+                await timeSeeder(manager).ConfigureAwait(false);
+            };
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configure a custom seeder for cron tickers, executed on application startup.
+        /// </summary>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(
+            Func<ICronTickerManager<TCronTicker>, System.Threading.Tasks.Task> cronSeeder)
+        {
+            if (cronSeeder == null) return this;
+
+            CronSeederAction = async sp =>
+            {
+                var manager = sp.GetRequiredService<ICronTickerManager<TCronTicker>>();
+                await cronSeeder(manager).ConfigureAwait(false);
+            };
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configure custom seeders for both time and cron tickers, executed on application startup.
+        /// </summary>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> UseTickerSeeder(
+            Func<ITimeTickerManager<TTimeTicker>, System.Threading.Tasks.Task> timeSeeder,
+            Func<ICronTickerManager<TCronTicker>, System.Threading.Tasks.Task> cronSeeder)
+        {
+            UseTickerSeeder(timeSeeder);
+            UseTickerSeeder(cronSeeder);
             return this;
         }
         

--- a/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
+++ b/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
@@ -38,6 +38,9 @@ namespace TickerQ.DependencyInjection
             {
                 TickerHelper.RequestJsonSerializerOptions = optionInstance.RequestJsonSerializerOptions;
             }
+            
+            // Configure whether ticker request payloads should use GZip compression
+            TickerHelper.UseGZipCompression = optionInstance.RequestGZipCompressionEnabled;
             services.AddSingleton<ITimeTickerManager<TTimeTicker>, TickerManager<TTimeTicker, TCronTicker>>();
             services.AddSingleton<ICronTickerManager<TCronTicker>, TickerManager<TTimeTicker, TCronTicker>>();
             services.AddSingleton<IInternalTickerManager, InternalTickerManager<TTimeTicker, TCronTicker>>();
@@ -99,14 +102,31 @@ namespace TickerQ.DependencyInjection
                 else if (type == CoreNotifyActionType.NotifyThreadCount)
                     notificationHubSender.UpdateActiveThreads(value);
             };
+            
+            // Run core seeding pipeline based on main options (works for both in-memory and EF providers).
+            var options = tickerExecutionContext.OptionsSeeding;
 
+            if (options == null || options.SeedDefinedCronTickers)
+            {
+                SeedDefinedCronTickers(serviceProvider).GetAwaiter().GetResult();
+            }
+
+            if (options?.TimeSeederAction != null)
+            {
+                options.TimeSeederAction(serviceProvider).GetAwaiter().GetResult();
+            }
+
+            if (options?.CronSeederAction != null)
+            {
+                options.CronSeederAction(serviceProvider).GetAwaiter().GetResult();
+            }
+
+            // Let external providers (e.g., EF Core) perform their own startup logic (dead-node cleanup, etc.).
             if (tickerExecutionContext.ExternalProviderApplicationAction != null)
             {
                 tickerExecutionContext.ExternalProviderApplicationAction(serviceProvider);
                 tickerExecutionContext.ExternalProviderApplicationAction = null;
             }
-            else
-                SeedDefinedCronTickers(serviceProvider).GetAwaiter().GetResult();
             
             if (tickerExecutionContext?.DashboardApplicationAction != null)
             {

--- a/src/TickerQ/Exceptions/TerminateExecutionException.cs
+++ b/src/TickerQ/Exceptions/TerminateExecutionException.cs
@@ -3,7 +3,7 @@ using TickerQ.Utilities.Enums;
 
 namespace TickerQ.Exceptions
 {
-    internal class TerminateExecutionException : Exception
+    public class TerminateExecutionException : Exception
     {
         internal readonly TickerStatus Status = TickerStatus.Skipped;
         public TerminateExecutionException(string message) : base(message) { }

--- a/src/TickerQ/Src/TickerExecutionTaskHandler.cs
+++ b/src/TickerQ/Src/TickerExecutionTaskHandler.cs
@@ -147,7 +147,7 @@ internal class TickerExecutionTaskHandler
             Id = context.TickerId,
             Type = context.Type,
             IsDue = isDue,
-            CancelOperationAction = () => cancellationTokenSource.Cancel(),
+            RequestCancelOperationAction = () => cancellationTokenSource.Cancel(),
             CronOccurrenceOperations = new CronOccurrenceOperations
             {
                 SkipIfAlreadyRunningAction = () =>


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 8.x.x)
- ✅ Updated target framework (net10.0 → net8.0)
- ✅ Preserved .csproj files from net8 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end time zone handling in the dashboard, centralizes/streamlines seeding in core with smarter EF cron migration, and introduces optional GZip compression for ticker requests.
> 
> - **Dashboard (Backend + Frontend)**
>   - Expose scheduler time zone via `/api/options` (`schedulerTimeZone`) and accept `timeZoneId` on `time-ticker/add|update` to convert times to UTC.
>   - Add `timeZoneStore`, UI selector, and reactive refresh; unify date formatting with `formatDate(..., timeZone)` and remove ad‑hoc UTC→local hacks.
>   - Wire services/components to pass/display in selected zone (`CRUDTimeTickerDialog`, `TimeTicker.vue`, `CronTicker.vue`, `Dashboard.vue`), and update graphs/tables accordingly.
>   - Default dashboard base path set to ``/tickerq/dashboard``; fix SignalR hub URL when base path is `/`.
> - **Core/Options & Seeding**
>   - Introduce `ITickerOptionsSeeding` in `TickerOptionsBuilder` with `IgnoreSeedDefinedCronTickers` and `UseTickerSeeder(...)`; run seeding in `UseTickerQ` before provider hooks.
>   - Make cron seeding smarter in EF: delete obsolete seeded tickers, update changed expressions, insert missing ones (`MemoryTicker_Seeded_*`).
>   - Safer fallback worker when scheduler is frozen/disposed; `TerminateExecutionException` is now public; rename cancellation to `RequestCancellation` in function context.
> - **Request payloads**
>   - Add `UseGZipCompression()` option; plumb to `TickerHelper` to toggle compression for ticker requests.
> - **Dashboard Auth/Docs**
>   - Replace `WithBearerToken` with `WithApiKey`; simplify `WithHostAuthentication()`; README and samples updated.
> - **Cleanup/DI**
>   - Remove legacy dashboard auth service registrations; minor cors/static hosting kept; small styles/typos fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8435cec297c9100db38f5f6dbbdf69891f7304b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->