### PR TITLE
Fix schema assignment logic and add SetSchema method

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
+++ b/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
@@ -25,8 +25,7 @@ namespace TickerQ.EntityFrameworkCore
         
         public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerQDbContext<TDbContext>(Action<DbContextOptionsBuilder> optionsAction, string schema = null) where TDbContext : TickerQDbContext<TTimeTicker, TCronTicker>
         {
-            if(!string.IsNullOrEmpty(schema))
-                Schema = schema;
+            Schema = schema ?? Schema;
             
             ServiceBuilder.UseTickerQDbContext<TDbContext, TTimeTicker, TCronTicker>(this, optionsAction);
             return this;


### PR DESCRIPTION
Improve the schema assignment logic in `UseTickerQDbContext` and introduce a new `SetSchema` method for better schema management.

Fixes: #414 