### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
+++ b/src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs
@@ -25,8 +25,7 @@ namespace TickerQ.EntityFrameworkCore
         
         public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> UseTickerQDbContext<TDbContext>(Action<DbContextOptionsBuilder> optionsAction, string schema = null) where TDbContext : TickerQDbContext<TTimeTicker, TCronTicker>
         {
-            if(string.IsNullOrEmpty(schema))
-                schema = Schema;
+            Schema = schema ?? Schema;
             
             ServiceBuilder.UseTickerQDbContext<TDbContext, TTimeTicker, TCronTicker>(this, optionsAction);
             return this;
@@ -35,6 +34,12 @@ namespace TickerQ.EntityFrameworkCore
         public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> SetDbContextPoolSize(int poolSize)
         {
             PoolSize = poolSize;
+            return this;
+        }
+
+        public TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker> SetSchema(string schema)
+        {
+            Schema = schema;
             return this;
         }
     }


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 8.x.x)
- ✅ Updated target framework (net10.0 → net8.0)
- ✅ Preserved .csproj files from net8 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds SetSchema and updates UseTickerQDbContext to persist the provided schema to the internal Schema field.
> 
> - **EF Core options** (`src/TickerQ.EntityFrameworkCore/EfCoreOptionBuilder.cs`):
>   - **Schema handling**: `UseTickerQDbContext` now assigns `Schema = schema ?? Schema` to persist provided schema.
>   - **New API**: `SetSchema(string schema)` to explicitly set the internal `Schema`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc52b0dab4b9ca150e1d3c59ac5f013a626096bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->