### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/src/TickerQ.Utilities/Enums/TickerQStartMode.cs
+++ b/src/TickerQ.Utilities/Enums/TickerQStartMode.cs
@@ -2,7 +2,16 @@ namespace TickerQ.Utilities.Enums
 {
     public enum TickerQStartMode
     {
+        /// <summary>
+        /// Start job processing immediately when UseTickerQ is called.
+        /// Background services are registered and start automatically.
+        /// </summary>
         Immediate,
+        
+        /// <summary>
+        /// Background services are registered but skip the first run.
+        /// Job processing needs to be started manually via ITickerQHostScheduler.
+        /// </summary>
         Manual
     }
 }

--- a/src/TickerQ.Utilities/Interfaces/ITickerQDispatcher.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerQDispatcher.cs
@@ -6,6 +6,12 @@ namespace TickerQ.Utilities.Interfaces
 {
     public interface ITickerQDispatcher
     {
+        /// <summary>
+        /// Indicates whether the dispatcher is functional (background services enabled).
+        /// When false, DispatchAsync will be a no-op.
+        /// </summary>
+        bool IsEnabled { get; }
+        
         Task DispatchAsync(InternalFunctionContext[] contexts, CancellationToken cancellationToken = default);
     }
 }

--- a/src/TickerQ.Utilities/Managers/TickerManager.cs
+++ b/src/TickerQ.Utilities/Managers/TickerManager.cs
@@ -103,7 +103,8 @@ namespace TickerQ.Utilities.Managers
                 // Persist first
                 await _persistenceProvider.AddTimeTickers([entity], cancellationToken: cancellationToken);
 
-                if (executionTime <= now.AddSeconds(1))
+                // Only try to dispatch immediately if dispatcher is enabled (background services running)
+                if (_dispatcher.IsEnabled && executionTime <= now.AddSeconds(1))
                 {
                     // Acquire and mark InProgress in one provider call
                     var acquired = await _persistenceProvider
@@ -347,7 +348,8 @@ namespace TickerQ.Utilities.Managers
 
                 await _notificationHubSender.AddTimeTickersBatchNotifyAsync().ConfigureAwait(false);
 
-                if (immediateTickers.Count > 0)
+                // Only try to dispatch immediately if dispatcher is enabled (background services running)
+                if (_dispatcher.IsEnabled && immediateTickers.Count > 0)
                 {
                     var acquired = await _persistenceProvider
                         .AcquireImmediateTimeTickersAsync(immediateTickers.ToArray(), cancellationToken)

--- a/src/TickerQ.Utilities/Temps/NoOpTickerQDispatcher.cs
+++ b/src/TickerQ.Utilities/Temps/NoOpTickerQDispatcher.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TickerQ.Utilities.Interfaces;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.Utilities.Temps;
+
+/// <summary>
+/// No-operation implementation of ITickerQDispatcher.
+/// Used when background services are disabled (queue-only mode).
+/// </summary>
+internal class NoOpTickerQDispatcher : ITickerQDispatcher
+{
+    public bool IsEnabled => false;
+    
+    public Task DispatchAsync(InternalFunctionContext[] contexts, CancellationToken cancellationToken = default)
+    {
+        // No-op: dispatcher not available in queue-only mode
+        return Task.CompletedTask;
+    }
+}

--- a/src/TickerQ.Utilities/Temps/NoOpTickerQHostScheduler.cs
+++ b/src/TickerQ.Utilities/Temps/NoOpTickerQHostScheduler.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TickerQ.Utilities.Interfaces;
+
+namespace TickerQ.Utilities.Temps;
+
+/// <summary>
+/// No-operation implementation of ITickerQHostScheduler.
+/// Used when background services are disabled (queue-only mode).
+/// </summary>
+internal class NoOpTickerQHostScheduler : ITickerQHostScheduler
+{
+    public bool IsRunning => false;
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public void RestartIfNeeded(DateTime? dateTime)
+    {
+        // No-op: scheduler not running
+    }
+
+    public void Restart()
+    {
+        // No-op: scheduler not running
+    }
+}

--- a/src/TickerQ.Utilities/TickerOptionsBuilder.cs
+++ b/src/TickerQ.Utilities/TickerOptionsBuilder.cs
@@ -34,6 +34,12 @@ namespace TickerQ.Utilities
         /// Defaults to true.
         /// </summary>
         internal bool SeedDefinedCronTickers { get; set; } = true;
+        
+        /// <summary>
+        /// Controls whether background services (job processors) should be registered.
+        /// Defaults to true. Set to false to only register managers for queuing jobs.
+        /// </summary>
+        internal bool RegisterBackgroundServices { get; set; } = true;
 
         /// <summary>
         /// Seeding delegate for time tickers, executed with the application's service provider.
@@ -96,6 +102,17 @@ namespace TickerQ.Utilities
         public TickerOptionsBuilder<TTimeTicker, TCronTicker> IgnoreSeedDefinedCronTickers()
         {
             SeedDefinedCronTickers = false;
+            return this;
+        }
+        
+        /// <summary>
+        /// Disables background services registration. 
+        /// Use this when you only want to queue jobs without processing them in this application.
+        /// Only the managers (ITimeTickerManager, ICronTickerManager) will be available for queuing jobs.
+        /// </summary>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> DisableBackgroundServices()
+        {
+            RegisterBackgroundServices = false;
             return this;
         }
 

--- a/src/TickerQ/Src/Dispatcher/TickerQDispatcher.cs
+++ b/src/TickerQ/Src/Dispatcher/TickerQDispatcher.cs
@@ -12,6 +12,8 @@ namespace TickerQ.Dispatcher
         private readonly TickerQTaskScheduler _taskScheduler;
         private readonly TickerExecutionTaskHandler _taskHandler;
 
+        public bool IsEnabled => true;
+
         public TickerQDispatcher(TickerQTaskScheduler taskScheduler, TickerExecutionTaskHandler taskHandler)
         {
             _taskScheduler = taskScheduler ?? throw new ArgumentNullException(nameof(taskScheduler));

--- a/tests/TickerQ.Tests/TickerOptionsBuilderTests.cs
+++ b/tests/TickerQ.Tests/TickerOptionsBuilderTests.cs
@@ -151,4 +151,28 @@ public class TickerOptionsBuilderTests
         schedulerOptions.MaxConcurrency.Should().Be(42);
         schedulerOptions.NodeIdentifier.Should().Be("test-node");
     }
+
+    [Fact]
+    public void DisableBackgroundServices_Sets_Flag_To_False()
+    {
+        var executionContext = new TickerExecutionContext();
+        var schedulerOptions = new SchedulerOptionsBuilder();
+
+        var builder = new TickerOptionsBuilder<FakeTimeTicker, FakeCronTicker>(executionContext, schedulerOptions);
+
+        // Default should be true
+        var defaultFlag = typeof(TickerOptionsBuilder<FakeTimeTicker, FakeCronTicker>)
+            .GetProperty("RegisterBackgroundServices", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(builder);
+        defaultFlag.Should().BeOfType<bool>().Which.Should().BeTrue();
+
+        // After calling DisableBackgroundServices, should be false
+        builder.DisableBackgroundServices();
+
+        var flag = typeof(TickerOptionsBuilder<FakeTimeTicker, FakeCronTicker>)
+            .GetProperty("RegisterBackgroundServices", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(builder);
+
+        flag.Should().BeOfType<bool>().Which.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 8.x.x)
- ✅ Updated target framework (net10.0 → net8.0)
- ✅ Preserved .csproj files from net8 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce an option to disable background services (queue-only mode) with conditional DI, no-op dispatcher/scheduler, and guarded immediate dispatch.
> 
> - **Options/Config**:
>   - Add `DisableBackgroundServices()` with internal flag `RegisterBackgroundServices` (default `true`).
>   - Enhance `TickerQStartMode` with XML docs.
> - **Dependency Injection**:
>   - Conditionally register background services in `AddTickerQ(...)` based on `RegisterBackgroundServices`.
>   - When disabled, register no-op `ITickerQHostScheduler` and `ITickerQDispatcher`.
> - **Dispatcher**:
>   - Extend `ITickerQDispatcher` with `IsEnabled`.
>   - Implement `IsEnabled` in `TickerQDispatcher` and add `NoOpTickerQDispatcher`.
> - **Manager Behavior**:
>   - In `TickerManager`, immediate dispatch for single and batch time tickers only when `_dispatcher.IsEnabled`.
> - **Hosting**:
>   - `UseTickerQ(...)` only configures background scheduler when present; otherwise skips.
> - **Tests**:
>   - Add unit test verifying `DisableBackgroundServices` flips `RegisterBackgroundServices` to `false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a425fdb554ddbed9e034bd70bcbc5ab2c04e5b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->