### PR TITLE
fix: Namespace conflicts for ModuleInitializer attribute

### DIFF
--- a/src/TickerQ.SourceGenerator/TickerQIncrementalSourceGenerator.cs
+++ b/src/TickerQ.SourceGenerator/TickerQIncrementalSourceGenerator.cs
@@ -415,7 +415,7 @@ namespace TickerQ.SourceGenerator
             var delegateList = delegates.ToList();
             var delegateCount = delegateList.Count;
             
-            sb.AppendLine("        [System.Runtime.CompilerServices.ModuleInitializer]");
+            sb.AppendLine("        [global::System.Runtime.CompilerServices.ModuleInitializer]");
             sb.AppendLine("        public static void Initialize()");
             sb.AppendLine("        {");
             
@@ -440,7 +440,7 @@ namespace TickerQ.SourceGenerator
             var delegateList = delegates.ToList();
             var delegateCount = delegateList.Count;
             
-            sb.AppendLine("[System.Runtime.CompilerServices.ModuleInitializer]");
+            sb.AppendLine("[global::System.Runtime.CompilerServices.ModuleInitializer]");
             sb.AppendLine("    public static void Initialize()");
             sb.AppendLine("    {");
             


### PR DESCRIPTION
This pull request makes a minor update to the way the `ModuleInitializer` attribute is referenced in the source generator. The change ensures that the attribute uses a fully qualified namespace, which can help avoid potential naming conflicts.

## Reproduce steps
1. Rename the sample project TickerQ.Sample.Console to TickerQ.Sample.System.Console.
2. Build the project (`dotnet build`)
3. See the build error:
```
TickerQ/samples/TickerQ.Sample.System.Console/obj/Debug/net10.0/TickerQ.SourceGenerator/TickerQ.SourceGenerator.TickerQIncrementalSourceGenerator/TickerQInstanceFactory.g.cs(17,17): error CS0234: The type or namespace name 'Runtime' does not exist in the namespace 'TickerQ.Sample.System' (are you missing an assembly reference?)
```