### PR TITLE
fix update ExecutionTime for CronTickerOccurrence

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
@@ -140,6 +140,12 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.LockHolder, (string)null)
                     .SetProperty(x => x.LockedAt, (DateTime?)null);
             }
+
+            // EXECUTION TIME
+            if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutionTime)))
+            {
+                setters.SetProperty(x => x.ExecutionTime, functionContext.ExecutionTime);
+            }
         }
 
         internal static void UpdateTimeTicker<TTimeTicker>(this UpdateSettersBuilder<TTimeTicker> setters,


### PR DESCRIPTION
The ExecutionTime property of CronTickerOccurrence is not updated when the CronTicker's Cron expression changes after the next occurrence has already been calculated. This results in two CronTickerOccurrences in the database (one with the old ExecutionTime and one with the new), causing the task to be executed twice.