### PR TITLE
🔄 Sync main branch changes to net8

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
@@ -117,11 +117,25 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     s => s.SetProperty(x => x.RetryCount, functionContext.RetryCount));
 
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ReleaseLock)))
+<<<<<<< HEAD
                 setExpression = ExpressionHelper.CombineSetters(setExpression,
                     s => s.SetProperty(x => x.LockHolder, (string)null)
                         .SetProperty(x => x.LockedAt, (DateTime?)null));
             
             return setExpression;
+=======
+            {
+                setters
+                    .SetProperty(x => x.LockHolder, (string)null)
+                    .SetProperty(x => x.LockedAt, (DateTime?)null);
+            }
+
+            // EXECUTION TIME
+            if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutionTime)))
+            {
+                setters.SetProperty(x => x.ExecutionTime, functionContext.ExecutionTime);
+            }
+>>>>>>> 298ca68 (fix update ExecutionTime for CronTickerOccurrence (#461))
         }
         
         internal static Expression<Func<SetPropertyCalls<TTimeTicker>, SetPropertyCalls<TTimeTicker>>> UpdateTimeTicker<TTimeTicker>(InternalFunctionContext functionContext, DateTime updatedAt)


### PR DESCRIPTION
## 🤖 Automated Branch Sync

This PR syncs recent changes from `main` branch to `net8`.

### Changes Applied:
- ✅ Applied recent commits from main (using cherry-pick)
- ✅ Updated version numbers (10.x.x → 8.x.x)
- ✅ Updated target framework (net10.0 → net8.0)
- ✅ Preserved .csproj files from net8 branch
- ⏭️ Commits already in target branch were automatically excluded

### Review Notes:
- All .csproj files maintain net8 configurations
- Directory.Build.props has been updated for net8 compatibility
- Ready for testing on net8 environment

---
_Created automatically by branch sync workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `ExecutionTime` handling in `UpdateCronTickerOccurrence` and retains lock-release setters; however the file contains unresolved merge-conflict markers and mixed setter variables that need resolution.
> 
> - Adds conditional update for `ExecutionTime` in `UpdateCronTickerOccurrence`
> - Keeps conditional lock release updates for `LockHolder`/`LockedAt`
> - Note: `<<<<<<< HEAD`/`>>>>>>>` markers and mixed `setExpression` vs `setters` appear in `MappingExtensions.cs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 687f4e985c56d5c9a2dbb606c12b8fd1c47fb93d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->