### PR TITLE
Fix PR #481: missing await to AuthenticateHostAsync call

### DIFF
--- a/src/TickerQ.Dashboard/Authentication/AuthService.cs
+++ b/src/TickerQ.Dashboard/Authentication/AuthService.cs
@@ -35,7 +35,7 @@ public class AuthService : IAuthService
             // Authentication performed by host application
             if (_config.Mode == AuthMode.Host)
             {
-                return AuthenticateHostAsync(context);
+                return await AuthenticateHostAsync(context);
             }
 
             // Get authorization header or query parameter


### PR DESCRIPTION
@arcenox sorry there an issue in #481
We're inside an `async` method so tail call to other async methods must be awaited.

I'm noticing that none of those `Authenticate...` methods are actually asynchronous and they're all private, another fix could be to turn them all sync, which would be a hair more efficient.