### PR TITLE
Add missing ASP.NET Core package references to TickerQ.SDK

### DIFF
--- a/src/TickerQ.SDK/TickerQ.SDK.csproj
+++ b/src/TickerQ.SDK/TickerQ.SDK.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(DotNetVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(DotNetVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Results" Version="$(DotNetVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="$(DotNetVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="$(DotNetVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added package references for ASP.NET Core extension packages to resolve CS0234 build errors when deploying. The SDK uses ASP.NET Core types (IEndpointRouteBuilder, IEndpointFilter, Results, etc.) but was missing the required package references.

Added packages:
- Microsoft.AspNetCore.Http.Abstractions
- Microsoft.AspNetCore.Http.Results
- Microsoft.AspNetCore.Routing
- Microsoft.AspNetCore.Mvc.Abstractions

https://claude.ai/code/session_01XaNrB2LuCkTM6FRjxuUyt7