### PR TITLE
Remove invalid ASP.NET Core package references

### DIFF
--- a/src/TickerQ.SDK/TickerQ.SDK.csproj
+++ b/src/TickerQ.SDK/TickerQ.SDK.csproj
@@ -13,10 +13,6 @@
   <ItemGroup>
     <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(DotNetVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(DotNetVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Results" Version="$(DotNetVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="$(DotNetVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="$(DotNetVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The ASP.NET Core packages (Microsoft.AspNetCore.Http.Abstractions, etc.) don't exist as standalone NuGet packages for .NET 5+. They were discontinued after .NET Core 2.x and are only available through the shared framework.

Since TickerQ.SDK already uses Microsoft.NET.Sdk.Web, these types are automatically available through the implicit framework reference. The explicit package references were causing NU1102 errors during restore.

https://claude.ai/code/session_01XaNrB2LuCkTM6FRjxuUyt7