### PR TITLE
Enable NuGet package generation for Web SDK projects

### DIFF
--- a/src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
+++ b/src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <OutputType>Library</OutputType>
+        <IsPackable>true</IsPackable>
         <PackageId>TickerQ.Dashboard</PackageId>
         <Description>Dashboard UI for visualizing and monitoring TickerQ scheduled jobs, status, and system metrics.</Description>
         <PackageTags>$(PackageTags);dashboard;monitoring;scheduler;status;job;ui</PackageTags>

--- a/src/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
+++ b/src/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>TickerQ.RemoteExecutor</PackageId>

--- a/src/TickerQ.SDK/TickerQ.SDK.csproj
+++ b/src/TickerQ.SDK/TickerQ.SDK.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>TickerQ.SDK</AssemblyName>
     <PackageId>TickerQ.SDK</PackageId>


### PR DESCRIPTION
Microsoft.NET.Sdk.Web sets IsPackable=false by default. Added explicit IsPackable=true to TickerQ.SDK, TickerQ.RemoteExecutor, and TickerQ.Dashboard to ensure NuGet packages are generated during build.

https://claude.ai/code/session_01XaNrB2LuCkTM6FRjxuUyt7