### PR TITLE
Fix #521: Set explicit C# 12 language version for .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
         <Authors>Albert Kunushevci</Authors>
         <Company>Arcenox LLC</Company>
         <Copyright>Copyright © 2025 Arcenox LLC</Copyright>
+        <LangVersion>12.0</LangVersion>
     </PropertyGroup>
 
 </Project>

--- a/src/TickerQ/TickerQ.csproj
+++ b/src/TickerQ/TickerQ.csproj
@@ -4,7 +4,6 @@
         <Description>A lightweight, developer-friendly library for queuing and executing cron and time-based jobs in the background.</Description>
         <PackageTags>$(PackageTags);background-jobs;task-scheduling</PackageTags>
         <PackageId>TickerQ</PackageId>
-        <LangVersion>latest</LangVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 


### PR DESCRIPTION
Set LangVersion to 12.0 in Directory.Build.props for deterministic builds and remove the per-project LangVersion override from TickerQ.csproj. C# 12 is the latest language version compatible with .NET 8.

https://claude.ai/code/session_015JykuFsRPUz3q19jxYh7uy