### PR TITLE
Fix #511 and #517: null reference and orphaned cron ticker bugs

### DIFF
--- a/src/TickerQ/Src/TickerExecutionTaskHandler.cs
+++ b/src/TickerQ/Src/TickerExecutionTaskHandler.cs
@@ -183,6 +183,11 @@ internal class TickerExecutionTaskHandler : ITickerExecutionTaskHandler
 
                 stopWatch.Start();
 
+                if (context.CachedDelegate is null)
+                    throw new InvalidOperationException(
+                        $"Ticker function '{context.FunctionName}' was not found in the registered functions. " +
+                        "Ensure the function is properly decorated with [TickerFunction] attribute and the containing class is registered.");
+
                 // Create service scope - will be disposed automatically via await using
                 await using var scope = _serviceProvider.CreateAsyncScope();
                 tickerFunctionContext.SetServiceScope(scope);


### PR DESCRIPTION
- #511: Add null check for CachedDelegate in RunContextFunctionAsync with a clear InvalidOperationException message instead of cryptic NRE
- #517: Fix orphaned cron tickers not being cleaned up on restart when their expression was edited via the dashboard. The dashboard update wipes InitIdentifier, causing the seeded-only cleanup to miss them. Now checks all cron tickers against TickerFunctionProvider.TickerFunctions to remove any whose function no longer exists in code. Applied to EF Core, In-Memory, and Redis persistence providers.

https://claude.ai/code/session_015JykuFsRPUz3q19jxYh7uy