### PR TITLE
fix: add authorization to dashboard auth #408

### DIFF
--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -92,8 +92,10 @@ namespace TickerQ.Dashboard.DependencyInjection
 
                 // Set up routing and CORS
                 dashboardApp.UseRouting();
-                dashboardApp.UseAuthorization();
                 dashboardApp.UseCors("TickerQ_Dashboard_CORS");
+                
+                // Set up authorization
+                dashboardApp.UseAuthorization();
 
                 // Add authentication middleware (only protects API endpoints)
                 if (config.Auth.IsEnabled)


### PR DESCRIPTION
Fixes #408 by adding missing `UseAuthorization` between `UseRouting` and `UseEndpoints` calls