### PR TITLE
Fix DotNetVersion range for net9 — was incorrectly set to [10.0.0,11.…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
         <PackageIcon>icon.jpg</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>9.1.1</Version>
-        <DotNetVersion>[10.0.0,11.0.0)</DotNetVersion>
+        <DotNetVersion>[9.0.0,10.0.0)</DotNetVersion>
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
…0.0)