### PR TITLE
Add IsEnabled property to CronTickerEntity with full-stack support

### DIFF
--- a/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
+++ b/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
@@ -138,6 +138,10 @@ public static class DashboardEndpoints
             .WithName("UpdateCronTicker")
             .WithSummary("Update cron ticker");
 
+        apiGroup.MapPut("/cron-ticker/toggle", ToggleCronTicker<TTimeTicker, TCronTicker>)
+            .WithName("ToggleCronTicker")
+            .WithSummary("Toggle cron ticker enabled/disabled");
+
         apiGroup.MapPost("/cron-ticker/run", RunCronTickerOnDemand<TTimeTicker, TCronTicker>)
             .WithName("RunCronTickerOnDemand")
             .WithSummary("Run cron ticker on demand");
@@ -548,6 +552,23 @@ public static class DashboardEndpoints
         return Results.Json(new { 
             success = result.IsSucceeded, 
             message = result.IsSucceeded ? "Cron ticker updated successfully" : "Failed to update cron ticker"
+        }, dashboardOptions.DashboardJsonOptions);
+    }
+
+    private static async Task<IResult> ToggleCronTicker<TTimeTicker, TCronTicker>(
+        Guid id,
+        bool isEnabled,
+        ITickerDashboardRepository<TTimeTicker, TCronTicker> repository,
+        DashboardOptionsBuilder dashboardOptions,
+        CancellationToken cancellationToken)
+        where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        where TCronTicker : CronTickerEntity, new()
+    {
+        var success = await repository.ToggleCronTickerAsync(id, isEnabled, cancellationToken);
+
+        return Results.Json(new {
+            success,
+            message = success ? $"Cron ticker {(isEnabled ? "enabled" : "disabled")} successfully" : "Failed to toggle cron ticker"
         }, dashboardOptions.DashboardJsonOptions);
     }
 

--- a/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
@@ -569,6 +569,26 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
             return finalData;
         }
 
+        public async Task<bool> ToggleCronTickerAsync(Guid id, bool isEnabled, CancellationToken cancellationToken)
+        {
+            var cronTicker = await _persistenceProvider.GetCronTickerById(id, cancellationToken);
+            if (cronTicker == null)
+                return false;
+
+            cronTicker.IsEnabled = isEnabled;
+            cronTicker.UpdatedAt = DateTime.UtcNow;
+
+            var affectedRows = await _persistenceProvider.UpdateCronTickers([cronTicker], cancellationToken);
+
+            if (affectedRows > 0)
+            {
+                _tickerQHostScheduler.Restart();
+                await _notificationHubSender.UpdateCronTickerNotifyAsync(cronTicker);
+            }
+
+            return affectedRows > 0;
+        }
+
         public bool CancelTickerById(Guid tickerId)
             => TickerCancellationTokenManager.RequestTickerCancellationById(tickerId);
 

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
@@ -176,6 +176,16 @@ const getTimeTickersGraphData = () => {
     };
 }
 
+const toggleCronTicker = () => {
+    const baseHttp = useBaseHttpService<object, object>('single')
+    const requestAsync = async (id: string, isEnabled: boolean) => (await baseHttp.sendAsync("PUT", "cron-ticker/toggle", { paramData: { id, isEnabled } }));
+
+    return {
+        ...baseHttp,
+        requestAsync
+    };
+}
+
 export const cronTickerService = {
     getCronTickers,
     getCronTickersPaginated,
@@ -183,6 +193,7 @@ export const cronTickerService = {
     addCronTicker,
     deleteCronTicker,
     runCronTickerOnDemand,
+    toggleCronTicker,
     getTimeTickersGraphDataRange,
     getTimeTickersGraphDataRangeById,
     getTimeTickersGraphData

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/types/cronTickerService.types.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/types/cronTickerService.types.ts
@@ -12,6 +12,7 @@ export class GetCronTickerResponse {
     createdAt!:string;
     updatedAt!:string;
     retries!:number;
+    isEnabled!:boolean;
     actions:string|undefined = undefined;
 }
 
@@ -22,6 +23,7 @@ export class UpdateCronTickerRequest {
     retries?: number;
     description?: string;
     intervals?:number[];
+    isEnabled?: boolean;
 }
 
 export class GetCronTickerGraphDataRangeResponse{

--- a/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
@@ -42,6 +42,7 @@ const getCronTickerRangeGraphDataById = cronTickerService.getTimeTickersGraphDat
 const getCronTickersGraphDataAndParseToGraph = cronTickerService.getTimeTickersGraphData()
 const deleteCronTicker = cronTickerService.deleteCronTicker()
 const runCronTickerOnDemand = cronTickerService.runCronTickerOnDemand()
+const toggleCronTicker = cronTickerService.toggleCronTicker()
 
 // Pagination state
 const currentPage = ref(1)
@@ -74,6 +75,9 @@ const handlePageSizeChange = async (size: number) => {
 }
 
 const confirmDialog = useDialog<ConfirmDialogProps & { id: string }>().withComponent(
+  () => import('@/components/common/ConfirmDialog.vue'),
+)
+const toggleConfirmDialog = useDialog<ConfirmDialogProps & { id: string; isEnabled: boolean }>().withComponent(
   () => import('@/components/common/ConfirmDialog.vue'),
 )
 const cronOccurrenceDialog = useDialog<{
@@ -466,6 +470,36 @@ const RunCronTickerOnDemand = async (id: string) => {
   await runCronTickerOnDemand.requestAsync(id)
   await sleep(1000)
   await loadPageData()
+}
+
+const ToggleCronTickerEnabled = (id: string, isEnabled: boolean) => {
+  toggleConfirmDialog.open({
+    ...new ConfirmDialogProps(),
+    id,
+    isEnabled,
+    icon: isEnabled ? 'mdi-power-off' : 'mdi-power',
+    iconColor: isEnabled ? '#F44336' : '#4CAF50',
+    title: isEnabled ? 'Disable Cron Ticker' : 'Enable Cron Ticker',
+    text: isEnabled
+      ? 'Are you sure you want to disable this cron ticker? It will stop generating new occurrences.'
+      : 'Are you sure you want to enable this cron ticker? It will start generating occurrences again.',
+    confirmText: isEnabled ? 'Disable' : 'Enable',
+    confirmColor: isEnabled ? '#F44336' : '#4CAF50',
+  })
+}
+
+const onSubmitToggleConfirmDialog = async () => {
+  try {
+    const id = toggleConfirmDialog.propData?.id!
+    const isEnabled = toggleConfirmDialog.propData?.isEnabled!
+    toggleConfirmDialog.close()
+    await toggleCronTicker.requestAsync(id, isEnabled)
+    await loadPageData()
+  } catch (error: any) {
+    if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+      return
+    }
+  }
 }
 
 onMounted(async () => {
@@ -1221,6 +1255,23 @@ const refreshData = async () => {
 
             <template v-slot:item.actions="{ item }">
               <div class="action-buttons-container">
+                <!-- Enable/Disable Button -->
+                <div class="action-btn-wrapper">
+                  <v-tooltip location="top">
+                    <template v-slot:activator="{ props }">
+                      <button
+                        v-bind="props"
+                        @click="ToggleCronTickerEnabled(item.id, !item.isEnabled)"
+                        class="modern-action-btn"
+                        :class="item.isEnabled ? 'disable-btn' : 'enable-btn'"
+                      >
+                        <v-icon size="16">mdi-power</v-icon>
+                      </button>
+                    </template>
+                    <span>{{ item.isEnabled ? 'Disable' : 'Enable' }}</span>
+                  </v-tooltip>
+                </div>
+
                 <!-- Chart Button -->
                 <div class="action-btn-wrapper">
                   <v-tooltip location="top">
@@ -1288,6 +1339,8 @@ const refreshData = async () => {
                         v-bind="props"
                         @click="RunCronTickerOnDemand(item.id)"
                         class="modern-action-btn run-btn"
+                        :class="{ 'btn-disabled': !item.isEnabled }"
+                        :disabled="!item.isEnabled"
                       >
                         <v-icon size="16">mdi-play-outline</v-icon>
                       </button>
@@ -1353,6 +1406,12 @@ const refreshData = async () => {
       :dialog-props="confirmDialog.propData"
       @close="confirmDialog.close()"
       @confirm="onSubmitConfirmDialog"
+    />
+    <toggleConfirmDialog.Component
+      :is-open="toggleConfirmDialog.isOpen"
+      :dialog-props="toggleConfirmDialog.propData"
+      @close="toggleConfirmDialog.close()"
+      @confirm="onSubmitToggleConfirmDialog"
     />
   </div>
 </template> 
@@ -1872,6 +1931,28 @@ const refreshData = async () => {
   border-color: rgba(255, 255, 255, 0.15);
 }
 
+.enable-btn {
+  color: #4caf50;
+  border-color: rgba(76, 175, 80, 0.2);
+}
+
+.enable-btn:hover {
+  border-color: rgba(76, 175, 80, 0.5);
+  box-shadow: 0 8px 25px rgba(76, 175, 80, 0.4);
+  background: rgba(76, 175, 80, 0.15);
+}
+
+.disable-btn {
+  color: #ffa726;
+  border-color: rgba(255, 167, 38, 0.2);
+}
+
+.disable-btn:hover {
+  border-color: rgba(255, 167, 38, 0.5);
+  box-shadow: 0 8px 25px rgba(255, 167, 38, 0.4);
+  background: rgba(255, 167, 38, 0.15);
+}
+
 .table-container {
   background: linear-gradient(135deg, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0.15) 100%);
   border-radius: 12px;
@@ -2062,6 +2143,14 @@ const refreshData = async () => {
   border-color: rgba(229, 115, 115, 0.5);
   box-shadow: 0 8px 25px rgba(229, 115, 115, 0.4);
   background: rgba(229, 115, 115, 0.15);
+}
+
+.btn-disabled {
+  color: #616161 !important;
+  border-color: rgba(97, 97, 97, 0.2) !important;
+  opacity: 0.5;
+  cursor: not-allowed !important;
+  pointer-events: none;
 }
 
 .expression-tooltip {

--- a/src/TickerQ.EntityFrameworkCore/Configurations/CronTickerConfigurations.cs
+++ b/src/TickerQ.EntityFrameworkCore/Configurations/CronTickerConfigurations.cs
@@ -26,6 +26,10 @@ namespace TickerQ.EntityFrameworkCore.Configurations
             builder.HasIndex("Function", "Expression")
                 .HasDatabaseName("IX_Function_Expression");
 
+            builder.Property(e => e.IsEnabled)
+                .IsRequired()
+                .HasDefaultValue(true);
+
             builder.ToTable("CronTickers", _schema);
         }
     }

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -347,6 +347,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
                 var dbContext = session.Context;
                 return await dbContext.Set<TCronTicker>()
                     .AsNoTracking()
+                    .Where(x => x.IsEnabled)
                     .Select(MappingExtensions.ForCronTickerExpressions<CronTickerEntity>())
                     .ToArrayAsync(ct)
                     .ConfigureAwait(false);
@@ -361,6 +362,7 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
         var dbContext = session.Context;
         return await dbContext.Set<TCronTicker>()
             .AsNoTracking()
+            .Where(x => x.IsEnabled)
             .Select(MappingExtensions.ForCronTickerExpressions<CronTickerEntity>())
             .ToArrayAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
@@ -18,7 +18,8 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                 Expression = e.Expression,
                 Function = e.Function,
                 RetryIntervals = e.RetryIntervals,
-                Retries = e.Retries
+                Retries = e.Retries,
+                IsEnabled = e.IsEnabled
             };
 
         internal static Expression<Func<TTimeTicker, TimeTickerEntity>> ForQueueTimeTickers<TTimeTicker>()

--- a/src/TickerQ.Utilities/Entities/CronTickerEntity.cs
+++ b/src/TickerQ.Utilities/Entities/CronTickerEntity.cs
@@ -9,5 +9,6 @@ namespace TickerQ.Utilities.Entities
         public virtual byte[] Request { get; set; }
         public virtual int Retries { get; set; }
         public virtual int[] RetryIntervals { get; set; }
+        public virtual bool IsEnabled { get; set; } = true;
     }
 }

--- a/src/TickerQ.Utilities/Interfaces/ITickerDashboardRepository.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerDashboardRepository.cs
@@ -26,6 +26,7 @@ namespace TickerQ.Utilities.Interfaces
         Task<CronTickerOccurrenceEntity<TCronTicker>[]> GetCronTickersOccurrencesAsync(Guid guid, CancellationToken cancellationToken = default);
         Task<PaginationResult<CronTickerOccurrenceEntity<TCronTicker>>> GetCronTickersOccurrencesPaginatedAsync(Guid guid, int pageNumber, int pageSize, CancellationToken cancellationToken = default);
         Task<IList<CronOccurrenceTickerGraphData>> GetCronTickersOccurrencesGraphDataAsync(Guid guid, CancellationToken cancellationToken = default);
+        Task<bool> ToggleCronTickerAsync(Guid id, bool isEnabled, CancellationToken cancellationToken = default);
         bool CancelTickerById(Guid tickerId);
         Task DeleteCronTickerOccurrenceByIdAsync(Guid id, CancellationToken cancellationToken = default);
         Task<(string, int)> GetTickerRequestByIdAsync(Guid tickerId, TickerType tickerType, CancellationToken cancellationToken = default);

--- a/src/TickerQ/Src/Provider/TickerInMemoryPersistenceProvider.cs
+++ b/src/TickerQ/Src/Provider/TickerInMemoryPersistenceProvider.cs
@@ -563,9 +563,10 @@ namespace TickerQ.Provider
         public Task<CronTickerEntity[]> GetAllCronTickerExpressions(CancellationToken cancellationToken)
         {
             var result = CronTickers.Values
+                .Where(x => x.IsEnabled)
                 .Cast<CronTickerEntity>()
                 .ToArray();
-                
+
             return Task.FromResult(result);
         }
 

--- a/tests/TickerQ.Tests/RetryBehaviorTests.cs
+++ b/tests/TickerQ.Tests/RetryBehaviorTests.cs
@@ -4,12 +4,19 @@ using TickerQ.Utilities.Interfaces;
 using TickerQ.Utilities.Interfaces.Managers;
 using Microsoft.Extensions.DependencyInjection;
 using TickerQ.Utilities.Instrumentation;
+using TickerQ.Utilities;
 using TickerQ.Utilities.Models;
 
 namespace TickerQ.Tests;
 
-public class RetryBehaviorTests
+[Collection("TickerCancellationTokenState")]
+public class RetryBehaviorTests : IDisposable
 {
+    public void Dispose()
+    {
+        TickerCancellationTokenManager.CleanUpTickerCancellationTokens();
+    }
+
     // End-to-end unit tests that call the public ExecuteTaskAsync with a CronTickerOccurrence
     // so RunContextFunctionAsync + retry logic is exercised. Tests use short intervals (1..3s).
 

--- a/tests/TickerQ.Tests/RetryExhaustionTests.cs
+++ b/tests/TickerQ.Tests/RetryExhaustionTests.cs
@@ -9,8 +9,14 @@ using TickerQ.Utilities.Models;
 
 namespace TickerQ.Tests;
 
-public class RetryExhaustionTests
+[Collection("TickerCancellationTokenState")]
+public class RetryExhaustionTests : IDisposable
 {
+    public void Dispose()
+    {
+        TickerCancellationTokenManager.CleanUpTickerCancellationTokens();
+    }
+
     private readonly ITickerClock _clock;
     private readonly IInternalTickerManager _internalManager;
     private readonly ITickerQInstrumentation _instrumentation;

--- a/tests/TickerQ.Tests/TickerCancellationTokenManagerTests.cs
+++ b/tests/TickerQ.Tests/TickerCancellationTokenManagerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace TickerQ.Tests;
 
+[Collection("TickerCancellationTokenState")]
 public class TickerCancellationTokenManagerTests : IDisposable
 {
     public void Dispose()

--- a/tests/TickerQ.Tests/TickerExecutionTaskHandlerTests.cs
+++ b/tests/TickerQ.Tests/TickerExecutionTaskHandlerTests.cs
@@ -10,8 +10,14 @@ using TickerQ.Utilities.Models;
 
 namespace TickerQ.Tests;
 
-public class TickerExecutionTaskHandlerTests
+[Collection("TickerCancellationTokenState")]
+public class TickerExecutionTaskHandlerTests : IDisposable
 {
+    public void Dispose()
+    {
+        TickerCancellationTokenManager.CleanUpTickerCancellationTokens();
+    }
+
     private readonly ITickerClock _clock;
     private readonly IInternalTickerManager _internalManager;
     private readonly ITickerQInstrumentation _instrumentation;


### PR DESCRIPTION
Add ability to enable/disable cron tickers without deleting them. Disabled tickers are filtered out of the scheduling pipeline while remaining visible in the dashboard. Includes toggle endpoint, dashboard UI with confirmation dialog, and fixes flaky test caused by parallel test execution sharing static TickerCancellationTokenManager state.