### PR TITLE
Fix TickerModelCustomizer not applying configured schema

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
+++ b/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
@@ -16,9 +16,11 @@ namespace TickerQ.EntityFrameworkCore.Customizer
 
         public override void Customize(ModelBuilder builder, DbContext context)
         {
-            builder.ApplyConfiguration(new TimeTickerConfigurations<TTimeTicker>());
-            builder.ApplyConfiguration(new CronTickerConfigurations<TCronTicker>());
-            builder.ApplyConfiguration(new CronTickerOccurrenceConfigurations<TCronTicker>());
+            var schema = context.GetService<TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker>>().Schema;
+
+            builder.ApplyConfiguration(new TimeTickerConfigurations<TTimeTicker>(schema));
+            builder.ApplyConfiguration(new CronTickerConfigurations<TCronTicker>(schema));
+            builder.ApplyConfiguration(new CronTickerOccurrenceConfigurations<TCronTicker>(schema));
 
             base.Customize(builder, context);
         }


### PR DESCRIPTION
TickerModelCustomizer was calling configurations without passing the schema, causing migrations to always use the default "ticker" schema instead of the one set via SetSchema(). Now resolves the schema from TickerQEfCoreOptionBuilder, matching how TickerQDbContext does it.