### PR TITLE
Sync main → net9

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
+++ b/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
@@ -16,9 +16,11 @@ namespace TickerQ.EntityFrameworkCore.Customizer
 
         public override void Customize(ModelBuilder builder, DbContext context)
         {
-            builder.ApplyConfiguration(new TimeTickerConfigurations<TTimeTicker>());
-            builder.ApplyConfiguration(new CronTickerConfigurations<TCronTicker>());
-            builder.ApplyConfiguration(new CronTickerOccurrenceConfigurations<TCronTicker>());
+            var schema = context.GetService<TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker>>().Schema;
+
+            builder.ApplyConfiguration(new TimeTickerConfigurations<TTimeTicker>(schema));
+            builder.ApplyConfiguration(new CronTickerConfigurations<TCronTicker>(schema));
+            builder.ApplyConfiguration(new CronTickerOccurrenceConfigurations<TCronTicker>(schema));
 
             base.Customize(builder, context);
         }


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_