### PR TITLE
Sync main → net9

### DIFF
--- a/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
+++ b/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
@@ -27,6 +27,9 @@ public class DashboardOptionsBuilder
     /// Separate from request serialization options to prevent user configuration from breaking dashboard APIs.
     /// </summary>
     internal JsonSerializerOptions DashboardJsonOptions { get; set; }
+
+    /// <summary>Tracks whether dashboard middleware has been applied to prevent double registration.</summary>
+    internal bool MiddlewareApplied { get; set; }
     
     public void SetCorsPolicy(Action<CorsPolicyBuilder> corsPolicyBuilder)
         => CorsPolicyBuilder = corsPolicyBuilder;

--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using TickerQ.Dashboard.Endpoints;
 using TickerQ.Dashboard.Hubs;
+using TickerQ.Dashboard.Infrastructure;
 using TickerQ.Dashboard.Infrastructure.Dashboard;
 using TickerQ.Dashboard.Authentication;
 using TickerQ.Utilities;
@@ -8,6 +9,7 @@ using TickerQ.Utilities.Interfaces;
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using TickerQ.Utilities.Entities;
 
@@ -59,6 +61,10 @@ namespace TickerQ.Dashboard.DependencyInjection
                 
                 services.AddDashboardService<TTimeTicker, TCronTicker>(dashboardConfig);
                 services.AddSingleton<DashboardOptionsBuilder>(_ => dashboardConfig);
+
+                // Register IStartupFilter for old Startup.cs pattern where IHost != IApplicationBuilder.
+                // In the new WebApplication pattern, UseDashboardDelegate handles it directly.
+                services.AddSingleton<IStartupFilter>(new DashboardStartupFilter<TTimeTicker, TCronTicker>(dashboardConfig));
             };
 
             UseDashboardDelegate(tickerConfiguration, dashboardConfig);
@@ -72,16 +78,15 @@ namespace TickerQ.Dashboard.DependencyInjection
         {
             tickerConfiguration.UseDashboardApplication((appObj) =>
             {
-                if (appObj is not IApplicationBuilder app)
-                    throw new InvalidOperationException(
-                        "TickerQ Dashboard can only be used in ASP.NET Core applications. " +
-                        "The current host does not provide an HTTP application pipeline " +
-                        "(IApplicationBuilder is not available). " +
-                        "If you are running a Worker Service, Console app, or background node, " +
-                        "remove the dashboard configuration or move it to a WebApplication."
-                    );
-                // Configure static files and middleware with endpoints
-                app.UseDashboardWithEndpoints<TTimeTicker, TCronTicker>(dashboardConfig);
+                if (appObj is IApplicationBuilder app)
+                {
+                    // New WebApplication pattern: WebApplication implements both IHost and IApplicationBuilder.
+                    // Mark as applied so DashboardStartupFilter skips duplicate registration.
+                    dashboardConfig.MiddlewareApplied = true;
+                    app.UseDashboardWithEndpoints<TTimeTicker, TCronTicker>(dashboardConfig);
+                }
+                // Old Startup.cs pattern: IHost is not IApplicationBuilder.
+                // Dashboard middleware is injected via IStartupFilter registered in AddDashboard.
             });
         }
     }

--- a/src/TickerQ.Dashboard/Infrastructure/DashboardStartupFilter.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/DashboardStartupFilter.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using TickerQ.Dashboard.DependencyInjection;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.Dashboard.Infrastructure;
+
+internal class DashboardStartupFilter<TTimeTicker, TCronTicker> : IStartupFilter
+    where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+    where TCronTicker : CronTickerEntity, new()
+{
+    private readonly DashboardOptionsBuilder _config;
+
+    public DashboardStartupFilter(DashboardOptionsBuilder config)
+    {
+        _config = config;
+    }
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            // Only apply if not already applied by UseDashboardDelegate (new WebApplication pattern)
+            if (!_config.MiddlewareApplied)
+            {
+                _config.MiddlewareApplied = true;
+                app.UseDashboardWithEndpoints<TTimeTicker, TCronTicker>(_config);
+            }
+
+            next(app);
+        };
+    }
+}


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_