### PR TITLE
Sync main → net9

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,6 +10,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>9.1.1</Version>
         <DotNetVersion>[9.0.0,10.0.0)</DotNetVersion>
+        <DotNetAbstractionsVersion>[8.0.0,)</DotNetAbstractionsVersion>
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_