### PR TITLE
Fix empty request deserialization throwing JsonException

### DIFF
--- a/src/TickerQ.Utilities/TickerHelper.cs
+++ b/src/TickerQ.Utilities/TickerHelper.cs
@@ -73,8 +73,14 @@ namespace TickerQ.Utilities
 
         public static T ReadTickerRequest<T>(byte[] gzipBytes)
         {
+            if (gzipBytes == null || gzipBytes.Length == 0)
+                return default;
+
             var serializedObject = ReadTickerRequestAsString(gzipBytes);
-            
+
+            if (string.IsNullOrWhiteSpace(serializedObject))
+                return default;
+
             return JsonSerializer.Deserialize<T>(serializedObject, RequestJsonSerializerOptions);
         }
         

--- a/tests/TickerQ.Tests/TickerHelperTests.cs
+++ b/tests/TickerQ.Tests/TickerHelperTests.cs
@@ -151,6 +151,70 @@ public class TickerHelperTests : IDisposable
 
     #endregion
 
+    #region ReadTickerRequest - Null/Empty Input
+
+    [Fact]
+    public void ReadTickerRequest_NullBytes_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_EmptyBytes_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(Array.Empty<byte>());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_NullBytes_NullableValueType_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<int?>(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_EmptyBytes_WithCompression_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = true;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(Array.Empty<byte>());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_WhitespaceBytes_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<int?>(Encoding.UTF8.GetBytes("   "));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_WhitespaceBytes_ReferenceType_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(Encoding.UTF8.GetBytes(""));
+
+        Assert.Null(result);
+    }
+
+    #endregion
+
     #region Round-Trip Tests
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds null/empty guard in `TickerHelper.ReadTickerRequest<T>()` to return `default` instead of throwing `JsonException` when no request data is provided
- Also guards against whitespace-only deserialized strings
- Fixes the scenario where a `TickerFunction` with generic context (e.g., `TickerFunctionContext<int?>`) but no request data causes a noisy `JsonException` in logs

Fixes #463

## Test plan
- [x] Added unit tests for null byte array input
- [x] Added unit tests for empty byte array input  
- [x] Added unit tests for nullable value type with null input
- [x] Added unit tests for empty bytes with compression enabled
- [x] Added unit tests for whitespace-only bytes
- [x] All 15 TickerHelperTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)