### PR TITLE
Sync main → net9

### DIFF
--- a/src/TickerQ.Utilities/TickerHelper.cs
+++ b/src/TickerQ.Utilities/TickerHelper.cs
@@ -73,8 +73,14 @@ namespace TickerQ.Utilities
 
         public static T ReadTickerRequest<T>(byte[] gzipBytes)
         {
+            if (gzipBytes == null || gzipBytes.Length == 0)
+                return default;
+
             var serializedObject = ReadTickerRequestAsString(gzipBytes);
-            
+
+            if (string.IsNullOrWhiteSpace(serializedObject))
+                return default;
+
             return JsonSerializer.Deserialize<T>(serializedObject, RequestJsonSerializerOptions);
         }
         

--- a/tests/TickerQ.Tests/TickerHelperTests.cs
+++ b/tests/TickerQ.Tests/TickerHelperTests.cs
@@ -151,6 +151,70 @@ public class TickerHelperTests : IDisposable
 
     #endregion
 
+    #region ReadTickerRequest - Null/Empty Input
+
+    [Fact]
+    public void ReadTickerRequest_NullBytes_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_EmptyBytes_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(Array.Empty<byte>());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_NullBytes_NullableValueType_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<int?>(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_EmptyBytes_WithCompression_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = true;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(Array.Empty<byte>());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_WhitespaceBytes_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<int?>(Encoding.UTF8.GetBytes("   "));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReadTickerRequest_WhitespaceBytes_ReferenceType_ReturnsDefault()
+    {
+        TickerHelper.UseGZipCompression = false;
+
+        var result = TickerHelper.ReadTickerRequest<TestPayload>(Encoding.UTF8.GetBytes(""));
+
+        Assert.Null(result);
+    }
+
+    #endregion
+
     #region Round-Trip Tests
 
     [Fact]


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_