### PR TITLE
Sync main → net9

### DIFF
--- a/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
@@ -434,6 +434,7 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
                 {
                     context.CachedDelegate = tickerItem.Delegate;
                     context.CachedPriority = tickerItem.Priority;
+                    context.CachedMaxConcurrency = tickerItem.MaxConcurrency;
                 }
 
                 await _dispatcher.DispatchAsync([context], cancellationToken).ConfigureAwait(false);

--- a/src/TickerQ.RemoteExecutor/RemoteExecutionEndpoints.cs
+++ b/src/TickerQ.RemoteExecutor/RemoteExecutionEndpoints.cs
@@ -128,7 +128,7 @@ public static class RemoteExecutionEndpoints
                         sp => sp.GetRequiredService<TickerQRemoteExecutionOptions>().WebHookSignature,
                         allowEmptySecret: true);
 
-                    if (functionDict.TryAdd(newFunction.Name, (newFunction.CronExpression, newFunction.Priority, newFunctionDelegate)))
+                    if (functionDict.TryAdd(newFunction.Name, (newFunction.CronExpression, newFunction.Priority, newFunctionDelegate, 0)))
                     {
                         RemoteFunctionRegistry.MarkRemote(newFunction.Name);
                         requestInfoDict[newFunction.Name] = (newFunction.RequestType, newFunction.RequestExampleJson);

--- a/src/TickerQ.RemoteExecutor/RemoteFunctionsSyncService.cs
+++ b/src/TickerQ.RemoteExecutor/RemoteFunctionsSyncService.cs
@@ -184,7 +184,7 @@ public class RemoteFunctionsSyncService : BackgroundService
                 // Use cronExpression if available
                 var cronExpression = function.NodeExpression ?? string.Empty;
                 
-                functionDict[function.FunctionName] = (cronExpression, priority, functionDelegate);
+                functionDict[function.FunctionName] = (cronExpression, priority, functionDelegate, 0);
                 RemoteFunctionRegistry.MarkRemote(function.FunctionName);
                 requestInfoDict[function.FunctionName] = (
                     function.RequestType,

--- a/src/TickerQ.SDK/Infrastructure/TickerQFunctionSyncService.cs
+++ b/src/TickerQ.SDK/Infrastructure/TickerQFunctionSyncService.cs
@@ -37,7 +37,7 @@ internal sealed class TickerQFunctionSyncService
             if (requestType.Item2 != null)
                 JsonExampleGenerator.TryGenerateExampleJson(requestType.Item2, out exampleJson);
 
-            var (cronExpression, priority, _) = value;
+            var (cronExpression, priority, _, _) = value;
             node.Functions.Add(new NodeFunction
             {
                 FunctionName = name,

--- a/src/TickerQ.SDK/SdkExecutionEndpoint.cs
+++ b/src/TickerQ.SDK/SdkExecutionEndpoint.cs
@@ -75,12 +75,29 @@ public static class SdkExecutionEndpoint
             {
                 function.CachedDelegate = tickerItem.Delegate;
                 function.CachedPriority = tickerItem.Priority;
+                function.CachedMaxConcurrency = tickerItem.MaxConcurrency;
             }
             
             if (scheduler is not null && !scheduler.IsDisposed && !scheduler.IsFrozen)
             {
+                var concurrencyGate = scope.ServiceProvider.GetService<ITickerFunctionConcurrencyGate>();
+                var semaphore = concurrencyGate?.GetSemaphoreOrNull(function.FunctionName, function.CachedMaxConcurrency);
+
                 await scheduler.QueueAsync(
-                    ct => taskHandler.ExecuteTaskAsync(function, context.IsDue, ct),
+                    async ct =>
+                    {
+                        if (semaphore != null)
+                            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+
+                        try
+                        {
+                            await taskHandler.ExecuteTaskAsync(function, context.IsDue, ct).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            semaphore?.Release();
+                        }
+                    },
                     TickerTaskPriority.LongRunning,
                     cancellationToken: CancellationToken.None);
             }

--- a/src/TickerQ.SourceGenerator/AttributeSyntaxes/ExtractAttributeExtensions.cs
+++ b/src/TickerQ.SourceGenerator/AttributeSyntaxes/ExtractAttributeExtensions.cs
@@ -4,20 +4,21 @@ namespace TickerQ.SourceGenerator.AttributeSyntaxes
 {
     public static class ExtractAttributeExtensions
     {
-        public static (string functionName, string cronExpression, int taskPriority)
+        public static (string functionName, string cronExpression, int taskPriority, int maxConcurrency)
             GetTickerFunctionAttributeValues(this AttributeData attrData)
         {
             // If for some reason there is no ctor (should be rare), return defaults
             var ctor = attrData.AttributeConstructor;
             if (ctor == null)
             {
-                return (null, null, 0);
+                return (null, null, 0, 0);
             }
 
             var parameters = ctor.Parameters;
             string functionName = null;
             string cronExpression = null;
             int taskPriority = 0;
+            int maxConcurrency = 0;
 
             for (int i = 0; i < parameters.Length; i++)
             {
@@ -46,10 +47,16 @@ namespace TickerQ.SourceGenerator.AttributeSyntaxes
                             taskPriority = intValue;
                         }
                         break;
+                    case "maxConcurrency":
+                        if (value is int concurrencyValue)
+                        {
+                            maxConcurrency = concurrencyValue;
+                        }
+                        break;
                 }
             }
 
-            return (functionName, cronExpression, taskPriority);
+            return (functionName, cronExpression, taskPriority, maxConcurrency);
         }
     }
 }

--- a/src/TickerQ.SourceGenerator/Generators/DelegateGenerator.cs
+++ b/src/TickerQ.SourceGenerator/Generators/DelegateGenerator.cs
@@ -54,6 +54,7 @@ namespace TickerQ.SourceGenerator.Generators
             string functionName,
             int functionPriority,
             string cronExpression,
+            int maxConcurrency = 0,
             string assemblyName = null,
             HashSet<string> classNameConflicts = null,
             HashSet<string> typeNameConflicts = null)
@@ -73,7 +74,7 @@ namespace TickerQ.SourceGenerator.Generators
             AddStandardParameter(methodDeclaration, parametersList);
             GenerateMethodCall(sb, classDeclaration, methodDeclaration, parametersList, methodInfo, assemblyName, classNameConflicts, typeNameConflicts);
 
-            sb.AppendLine("            })));");
+            sb.AppendLine($"            }}), {maxConcurrency}));");
 
             return sb.ToString();
         }

--- a/src/TickerQ.SourceGenerator/TickerQIncrementalSourceGenerator.cs
+++ b/src/TickerQ.SourceGenerator/TickerQIncrementalSourceGenerator.cs
@@ -163,6 +163,7 @@ namespace TickerQ.SourceGenerator
                     attributeValues.functionName,
                     attributeValues.taskPriority,
                     attributeValues.cronExpression,
+                    attributeValues.maxConcurrency,
                     assemblyName ?? compilation.Assembly.Name,
                     classNameConflicts,
                     typeNameConflicts
@@ -180,21 +181,23 @@ namespace TickerQ.SourceGenerator
             string functionName,
             int functionPriority,
             string cronExpression,
+            int maxConcurrency,
             string assemblyName,
             HashSet<string> classNameConflicts = null,
             HashSet<string> typeNameConflicts = null)
         {
             var methodInfo = DelegateGenerator.AnalyzeMethodParameters(methodDeclaration, semanticModel);
             var isAwaitable = SourceGeneratorUtilities.IsMethodAwaitable(methodDeclaration);
-            
+
             var delegateCode = DelegateGenerator.GenerateDelegateCode(
-                classDeclaration, 
-                methodDeclaration, 
-                methodInfo, 
-                isAwaitable, 
-                functionName, 
-                functionPriority, 
+                classDeclaration,
+                methodDeclaration,
+                methodInfo,
+                isAwaitable,
+                functionName,
+                functionPriority,
                 cronExpression,
+                maxConcurrency,
                 assemblyName,
                 classNameConflicts,
                 typeNameConflicts);
@@ -429,7 +432,7 @@ namespace TickerQ.SourceGenerator
             
             if (delegateCount > 0)
             {
-                sb.AppendLine($"            var tickerFunctionDelegateDict = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>({delegateCount});");
+                sb.AppendLine($"            var tickerFunctionDelegateDict = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>({delegateCount});");
                 
                 foreach (var delegateCode in delegateList)
                 {
@@ -454,7 +457,7 @@ namespace TickerQ.SourceGenerator
             
             if (delegateCount > 0)
             {
-                sb.AppendLine($"      var tickerFunctionDelegateDict = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>({delegateCount});");
+                sb.AppendLine($"      var tickerFunctionDelegateDict = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>({delegateCount});");
                 
                 foreach (var delegateCode in delegateList)
                 {

--- a/src/TickerQ.SourceGenerator/Validation/AttributeValidator.cs
+++ b/src/TickerQ.SourceGenerator/Validation/AttributeValidator.cs
@@ -13,7 +13,7 @@ namespace TickerQ.SourceGenerator.Validation
         /// Validates all aspects of a TickerFunction attribute and its usage.
         /// </summary>
         public static void ValidateTickerFunctionAttribute(
-            (string functionName, string cronExpression, int taskPriority) attributeValues,
+            (string functionName, string cronExpression, int taskPriority, int maxConcurrency) attributeValues,
             ClassDeclarationSyntax classDeclaration,
             MethodDeclarationSyntax methodDeclaration,
             IMethodSymbol methodSymbol,
@@ -47,6 +47,16 @@ namespace TickerQ.SourceGenerator.Validation
                 {
                     usedFunctionNames.Add(attributeValues.functionName);
                 }
+            }
+
+            // Validate maxConcurrency
+            if (attributeValues.maxConcurrency < 0)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.InvalidMaxConcurrency,
+                    attributeLocation,
+                    attributeValues.functionName ?? methodDeclaration.Identifier.Text
+                ));
             }
 
             // Validate cron expression

--- a/src/TickerQ.SourceGenerator/Validation/DiagnosticDescriptors.cs
+++ b/src/TickerQ.SourceGenerator/Validation/DiagnosticDescriptors.cs
@@ -96,5 +96,14 @@ namespace TickerQ.SourceGenerator.Validation
             DiagnosticSeverity.Error,
             true
         );
+
+        public static readonly DiagnosticDescriptor InvalidMaxConcurrency = new DiagnosticDescriptor(
+            "TQ011",
+            "Invalid maxConcurrency value",
+            "The maxConcurrency value for function '{0}' must be >= 0 (0 = unlimited)",
+            "TickerQ.SourceGenerator",
+            DiagnosticSeverity.Error,
+            true
+        );
     }
 }

--- a/src/TickerQ.Utilities/Base/TickerFunctionAttribute.cs
+++ b/src/TickerQ.Utilities/Base/TickerFunctionAttribute.cs
@@ -7,17 +7,19 @@ namespace TickerQ.Utilities.Base
     public class TickerFunctionAttribute : Attribute
     {
         public TickerFunctionAttribute(string functionName, string cronExpression = null,
-            TickerTaskPriority taskPriority = TickerTaskPriority.Normal)
+            TickerTaskPriority taskPriority = TickerTaskPriority.Normal, int maxConcurrency = 0)
         {
             _ = functionName;
             _ = cronExpression;
             _ = taskPriority;
+            _ = maxConcurrency;
         }
 
-        public TickerFunctionAttribute(string functionName, TickerTaskPriority taskPriority)
+        public TickerFunctionAttribute(string functionName, TickerTaskPriority taskPriority, int maxConcurrency = 0)
         {
             _ = functionName;
             _ = taskPriority;
+            _ = maxConcurrency;
         }
     }
 }

--- a/src/TickerQ.Utilities/Interfaces/ITickerFunctionConcurrencyGate.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerFunctionConcurrencyGate.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+
+namespace TickerQ.Utilities.Interfaces
+{
+    public interface ITickerFunctionConcurrencyGate
+    {
+        /// <summary>
+        /// Returns a <see cref="SemaphoreSlim"/> that limits concurrency for the given function,
+        /// or <c>null</c> when <paramref name="maxConcurrency"/> is 0 (unlimited).
+        /// The semaphore is created lazily and cached for the lifetime of the application.
+        /// </summary>
+        SemaphoreSlim GetSemaphoreOrNull(string functionName, int maxConcurrency);
+    }
+}

--- a/src/TickerQ.Utilities/Managers/TickerManager.cs
+++ b/src/TickerQ.Utilities/Managers/TickerManager.cs
@@ -280,6 +280,7 @@ namespace TickerQ.Utilities.Managers
                 {
                     context.CachedDelegate = tickerItem.Delegate;
                     context.CachedPriority = tickerItem.Priority;
+                    context.CachedMaxConcurrency = tickerItem.MaxConcurrency;
                 }
 
                 if (context.TimeTickerChildren is { Count: > 0 })

--- a/src/TickerQ.Utilities/Models/InternalFunctionContext.cs
+++ b/src/TickerQ.Utilities/Models/InternalFunctionContext.cs
@@ -20,6 +20,7 @@ namespace TickerQ.Utilities.Models
         [JsonIgnore]
         public TickerFunctionDelegate CachedDelegate { get; set; }
         public TickerTaskPriority CachedPriority { get; set; }
+        public int CachedMaxConcurrency { get; set; }
         public string FunctionName { get; set; }
         public Guid TickerId { get; set; }
         public Guid? ParentId { get; set; }

--- a/src/TickerQ.Utilities/TickerExecutionContext.cs
+++ b/src/TickerQ.Utilities/TickerExecutionContext.cs
@@ -52,8 +52,9 @@ internal class TickerExecutionContext
          {
             context.CachedDelegate = tickerItem.Delegate;
             context.CachedPriority = tickerItem.Priority;
+            context.CachedMaxConcurrency = tickerItem.MaxConcurrency;
          }
-      
+
          if (context.TimeTickerChildren is { Count: > 0 })
          {
             var childrenSpan = CollectionsMarshal.AsSpan(context.TimeTickerChildren);

--- a/src/TickerQ.Utilities/TickerFunctionProvider.cs
+++ b/src/TickerQ.Utilities/TickerFunctionProvider.cs
@@ -23,12 +23,12 @@ namespace TickerQ.Utilities
         // Callback actions to collect registrations
         private static Action<Dictionary<string, (string, Type)>> _requestTypeRegistrations;
         private static Action<Dictionary<string, (string RequestType, string RequestExampleJson)>> _requestInfoRegistrations;
-        private static Action<Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate)>> _functionRegistrations;
+        private static Action<Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>> _functionRegistrations;
         
         // Final frozen dictionaries
         public static FrozenDictionary<string, (string, Type)> TickerFunctionRequestTypes;
         public static FrozenDictionary<string, (string RequestType, string RequestExampleJson)> TickerFunctionRequestInfos;
-        public static FrozenDictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate)> TickerFunctions;
+        public static FrozenDictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)> TickerFunctions;
 
         /// <summary>
         /// Registers ticker functions during application startup by adding to the callback chain.
@@ -36,7 +36,7 @@ namespace TickerQ.Utilities
         /// </summary>
         /// <param name="functions">The functions to register. Cannot be null.</param>
         /// <exception cref="ArgumentNullException">Thrown when functions parameter is null.</exception>
-        public static void RegisterFunctions(IDictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)> functions)
+        public static void RegisterFunctions(IDictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)> functions)
         {
             if (functions == null)
                 throw new ArgumentNullException(nameof(functions));
@@ -60,7 +60,7 @@ namespace TickerQ.Utilities
         /// <param name="functions">The functions to register. Cannot be null.</param>
         /// <param name="_">The total expected capacity (ignored - capacity calculated automatically).</param>
         /// <exception cref="ArgumentNullException">Thrown when functions parameter is null.</exception>
-        public static void RegisterFunctions(IDictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)> functions, int _)
+        public static void RegisterFunctions(IDictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)> functions, int _)
         {
             // For callback approach, capacity is calculated automatically in Build()
             RegisterFunctions(functions);
@@ -143,7 +143,7 @@ namespace TickerQ.Utilities
             
                         if (!string.IsNullOrEmpty(mappedCronExpression))
                         {
-                            dict[key] = (mappedCronExpression, value.Priority, value.Delegate);
+                            dict[key] = (mappedCronExpression, value.Priority, value.Delegate, value.MaxConcurrency);
                         }
                     }
                 }
@@ -162,7 +162,7 @@ namespace TickerQ.Utilities
             if (_functionRegistrations != null)
             {
                 // Single pass: execute callbacks directly on final dictionary
-                var functionsDict = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate)>();
+                var functionsDict = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>();
                 _functionRegistrations(functionsDict);
                 TickerFunctions = functionsDict.ToFrozenDictionary();
                 _functionRegistrations = null; // Release callback chain
@@ -171,7 +171,7 @@ namespace TickerQ.Utilities
             {
                 if (TickerFunctions == null)
                 {
-                    TickerFunctions = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate)>()
+                    TickerFunctions = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>()
                         .ToFrozenDictionary();
                 }
             }

--- a/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
+++ b/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
@@ -75,6 +75,7 @@ namespace TickerQ.DependencyInjection
                 services.AddSingleton<ITickerQHostScheduler, NoOpTickerQHostScheduler>();
                 services.AddSingleton<ITickerQDispatcher, NoOpTickerQDispatcher>();
             }
+            services.AddSingleton<ITickerFunctionConcurrencyGate, TickerFunctionConcurrencyGate>();
             services.AddSingleton<ITickerExecutionTaskHandler, TickerExecutionTaskHandler>();
             services.AddSingleton<ITickerQInstrumentation, LoggerInstrumentation>();
             

--- a/src/TickerQ/Src/BackgroundServices/TickerQFallbackBackgroundService.cs
+++ b/src/TickerQ/Src/BackgroundServices/TickerQFallbackBackgroundService.cs
@@ -14,14 +14,16 @@ internal class TickerQFallbackBackgroundService :  BackgroundService
     private readonly IInternalTickerManager _internalTickerManager;
     private readonly ITickerExecutionTaskHandler _tickerExecutionTaskHandler;
     private readonly ITickerQTaskScheduler _tickerQTaskScheduler;
+    private readonly ITickerFunctionConcurrencyGate _concurrencyGate;
     private readonly TimeSpan _fallbackJobPeriod;
 
-    public TickerQFallbackBackgroundService(IInternalTickerManager internalTickerManager, SchedulerOptionsBuilder schedulerOptions, ITickerExecutionTaskHandler tickerExecutionTaskHandler, ITickerQTaskScheduler tickerQTaskScheduler)
+    public TickerQFallbackBackgroundService(IInternalTickerManager internalTickerManager, SchedulerOptionsBuilder schedulerOptions, ITickerExecutionTaskHandler tickerExecutionTaskHandler, ITickerQTaskScheduler tickerQTaskScheduler, ITickerFunctionConcurrencyGate concurrencyGate)
     {
         _internalTickerManager = internalTickerManager;
         _fallbackJobPeriod = schedulerOptions.FallbackIntervalChecker;
         _tickerExecutionTaskHandler = tickerExecutionTaskHandler;
         _tickerQTaskScheduler = tickerQTaskScheduler;
+        _concurrencyGate = concurrencyGate;
     }
 
     public override Task StartAsync(CancellationToken ct)
@@ -54,6 +56,7 @@ internal class TickerQFallbackBackgroundService :  BackgroundService
                         {
                             function.CachedDelegate = tickerItem.Delegate;
                             function.CachedPriority = tickerItem.Priority;
+                            function.CachedMaxConcurrency = tickerItem.MaxConcurrency;
                         }
 
                         foreach (var child in function.TimeTickerChildren)
@@ -62,6 +65,7 @@ internal class TickerQFallbackBackgroundService :  BackgroundService
                             {
                                 child.CachedDelegate = childItem.Delegate;
                                 child.CachedPriority = childItem.Priority;
+                                child.CachedMaxConcurrency = childItem.MaxConcurrency;
                             }
 
                             foreach (var grandChild in child.TimeTickerChildren)
@@ -70,14 +74,30 @@ internal class TickerQFallbackBackgroundService :  BackgroundService
                                 {
                                     grandChild.CachedDelegate = grandChildItem.Delegate;
                                     grandChild.CachedPriority = grandChildItem.Priority;
+                                    grandChild.CachedMaxConcurrency = grandChildItem.MaxConcurrency;
                                 }
                             }
                         }
 
                         try
                         {
+                            var semaphore = _concurrencyGate.GetSemaphoreOrNull(function.FunctionName, function.CachedMaxConcurrency);
+
                             await _tickerQTaskScheduler.QueueAsync(
-                                ct => _tickerExecutionTaskHandler.ExecuteTaskAsync(function, true, ct),
+                                async ct =>
+                                {
+                                    if (semaphore != null)
+                                        await semaphore.WaitAsync(ct).ConfigureAwait(false);
+
+                                    try
+                                    {
+                                        await _tickerExecutionTaskHandler.ExecuteTaskAsync(function, true, ct).ConfigureAwait(false);
+                                    }
+                                    finally
+                                    {
+                                        semaphore?.Release();
+                                    }
+                                },
                                 function.CachedPriority,
                                 stoppingToken);
                         }

--- a/src/TickerQ/Src/BackgroundServices/TickerQSchedulerBackgroundService.cs
+++ b/src/TickerQ/Src/BackgroundServices/TickerQSchedulerBackgroundService.cs
@@ -20,22 +20,25 @@ internal class TickerQSchedulerBackgroundService : BackgroundService, ITickerQHo
     private SafeCancellationTokenSource _schedulerLoopCancellationTokenSource;
     private readonly ITickerQTaskScheduler  _taskScheduler;
     private readonly ITickerExecutionTaskHandler  _taskHandler;
+    private readonly ITickerFunctionConcurrencyGate _concurrencyGate;
     private int _started;
     public bool SkipFirstRun;
     public bool IsRunning => _started == 1;
 
-    
+
     public TickerQSchedulerBackgroundService(
         TickerExecutionContext executionContext,
-        ITickerExecutionTaskHandler taskHandler, 
-        ITickerQTaskScheduler taskScheduler, 
+        ITickerExecutionTaskHandler taskHandler,
+        ITickerQTaskScheduler taskScheduler,
         IInternalTickerManager  internalTickerManager,
-        SchedulerOptionsBuilder schedulerOptions)
+        SchedulerOptionsBuilder schedulerOptions,
+        ITickerFunctionConcurrencyGate concurrencyGate)
     {
         _executionContext = executionContext;
         _taskHandler = taskHandler;
         _taskScheduler = taskScheduler;
         _internalTickerManager = internalTickerManager ?? throw new ArgumentNullException(nameof(internalTickerManager));
+        _concurrencyGate = concurrencyGate;
         _minPollingInterval = ResolveMinPollingInterval(schedulerOptions);
         _restartThrottle = new RestartThrottleManager(() => _schedulerLoopCancellationTokenSource?.Cancel());
     }
@@ -102,7 +105,24 @@ internal class TickerQSchedulerBackgroundService : BackgroundService, ITickerQHo
                 await _internalTickerManager.SetTickersInProgress(_executionContext.Functions, cancellationToken);
 
                 foreach (var function in _executionContext.Functions.OrderBy(x => x.CachedPriority))
-                    _ = _taskScheduler.QueueAsync(async ct => await _taskHandler.ExecuteTaskAsync(function,false, ct), function.CachedPriority, stoppingToken);
+                {
+                    var semaphore = _concurrencyGate.GetSemaphoreOrNull(function.FunctionName, function.CachedMaxConcurrency);
+
+                    _ = _taskScheduler.QueueAsync(async ct =>
+                    {
+                        if (semaphore != null)
+                            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+
+                        try
+                        {
+                            await _taskHandler.ExecuteTaskAsync(function, false, ct).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            semaphore?.Release();
+                        }
+                    }, function.CachedPriority, stoppingToken);
+                }
                 
                 _executionContext.SetFunctions(null);
             }

--- a/src/TickerQ/Src/Dispatcher/TickerQDispatcher.cs
+++ b/src/TickerQ/Src/Dispatcher/TickerQDispatcher.cs
@@ -10,13 +10,15 @@ namespace TickerQ.Dispatcher
     {
         private readonly ITickerQTaskScheduler _taskScheduler;
         private readonly ITickerExecutionTaskHandler _taskHandler;
+        private readonly ITickerFunctionConcurrencyGate _concurrencyGate;
 
         public bool IsEnabled => true;
 
-        public TickerQDispatcher(ITickerQTaskScheduler taskScheduler, ITickerExecutionTaskHandler taskHandler)
+        public TickerQDispatcher(ITickerQTaskScheduler taskScheduler, ITickerExecutionTaskHandler taskHandler, ITickerFunctionConcurrencyGate concurrencyGate)
         {
             _taskScheduler = taskScheduler ?? throw new ArgumentNullException(nameof(taskScheduler));
             _taskHandler = taskHandler ?? throw new ArgumentNullException(nameof(taskHandler));
+            _concurrencyGate = concurrencyGate ?? throw new ArgumentNullException(nameof(concurrencyGate));
         }
 
         public async Task DispatchAsync(InternalFunctionContext[] contexts, CancellationToken cancellationToken = default)
@@ -26,8 +28,23 @@ namespace TickerQ.Dispatcher
 
             foreach (var context in contexts)
             {
+                var semaphore = _concurrencyGate.GetSemaphoreOrNull(context.FunctionName, context.CachedMaxConcurrency);
+
                 await _taskScheduler.QueueAsync(
-                    async ct => await _taskHandler.ExecuteTaskAsync(context, false, ct).ConfigureAwait(false),
+                    async ct =>
+                    {
+                        if (semaphore != null)
+                            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+
+                        try
+                        {
+                            await _taskHandler.ExecuteTaskAsync(context, false, ct).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            semaphore?.Release();
+                        }
+                    },
                     context.CachedPriority,
                     cancellationToken).ConfigureAwait(false);
             }

--- a/src/TickerQ/Src/TickerFunctionConcurrencyGate.cs
+++ b/src/TickerQ/Src/TickerFunctionConcurrencyGate.cs
@@ -1,0 +1,19 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using TickerQ.Utilities.Interfaces;
+
+namespace TickerQ
+{
+    internal sealed class TickerFunctionConcurrencyGate : ITickerFunctionConcurrencyGate
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
+
+        public SemaphoreSlim GetSemaphoreOrNull(string functionName, int maxConcurrency)
+        {
+            if (maxConcurrency <= 0)
+                return null;
+
+            return _semaphores.GetOrAdd(functionName, _ => new SemaphoreSlim(maxConcurrency, maxConcurrency));
+        }
+    }
+}

--- a/tests/TickerQ.Tests/TickerFunctionConcurrencyGateTests.cs
+++ b/tests/TickerQ.Tests/TickerFunctionConcurrencyGateTests.cs
@@ -1,0 +1,111 @@
+using System.Threading;
+using TickerQ;
+
+namespace TickerQ.Tests;
+
+public class TickerFunctionConcurrencyGateTests
+{
+    private readonly TickerFunctionConcurrencyGate _gate = new();
+
+    [Fact]
+    public void GetSemaphoreOrNull_ZeroMaxConcurrency_ReturnsNull()
+    {
+        var result = _gate.GetSemaphoreOrNull("Func1", 0);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetSemaphoreOrNull_NegativeMaxConcurrency_ReturnsNull()
+    {
+        var result = _gate.GetSemaphoreOrNull("Func1", -1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetSemaphoreOrNull_PositiveMaxConcurrency_ReturnsSemaphore()
+    {
+        var result = _gate.GetSemaphoreOrNull("Func1", 3);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.CurrentCount);
+    }
+
+    [Fact]
+    public void GetSemaphoreOrNull_SameFunctionName_ReturnsSameInstance()
+    {
+        var first = _gate.GetSemaphoreOrNull("Func1", 2);
+        var second = _gate.GetSemaphoreOrNull("Func1", 2);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetSemaphoreOrNull_DifferentFunctionNames_ReturnDifferentInstances()
+    {
+        var funcA = _gate.GetSemaphoreOrNull("FuncA", 1);
+        var funcB = _gate.GetSemaphoreOrNull("FuncB", 1);
+
+        Assert.NotSame(funcA, funcB);
+    }
+
+    [Fact]
+    public void GetSemaphoreOrNull_MaxConcurrencyOne_LimitsToOneSlot()
+    {
+        var semaphore = _gate.GetSemaphoreOrNull("Serial", 1);
+
+        Assert.Equal(1, semaphore!.CurrentCount);
+
+        // Acquire the single slot
+        semaphore.Wait(0);
+        Assert.Equal(0, semaphore.CurrentCount);
+
+        // Release it
+        semaphore.Release();
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task GetSemaphoreOrNull_EnforcesConcurrencyLimit()
+    {
+        var semaphore = _gate.GetSemaphoreOrNull("Limited", 2);
+        var concurrentCount = 0;
+        var maxObserved = 0;
+        var tasks = new List<Task>();
+
+        for (int i = 0; i < 10; i++)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                await semaphore!.WaitAsync();
+                try
+                {
+                    var current = Interlocked.Increment(ref concurrentCount);
+                    InterlockedMax(ref maxObserved, current);
+                    await Task.Delay(20);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref concurrentCount);
+                    semaphore.Release();
+                }
+            }));
+        }
+
+        await Task.WhenAll(tasks);
+
+        Assert.True(maxObserved <= 2, $"Expected max concurrency of 2, but observed {maxObserved}");
+        Assert.True(maxObserved >= 1, "At least one task should have run concurrently");
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+            if (value <= current) return;
+        } while (Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+}

--- a/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
+++ b/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
@@ -54,9 +54,9 @@ public class TickerFunctionProviderTests : IDisposable
     [Fact]
     public void RegisterFunctions_And_Build_FunctionExists()
     {
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["MyFunc"] = ("*/5 * * * *", TickerTaskPriority.Normal, NoOpDelegate)
+            ["MyFunc"] = ("*/5 * * * *", TickerTaskPriority.Normal, NoOpDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions);
@@ -73,9 +73,9 @@ public class TickerFunctionProviderTests : IDisposable
     [Fact]
     public void RegisterFunctions_WithCapacity_DoesNotThrow()
     {
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["CapFunc"] = ("0 0 * * *", TickerTaskPriority.High, NoOpDelegate)
+            ["CapFunc"] = ("0 0 * * *", TickerTaskPriority.High, NoOpDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions, 100);
@@ -137,9 +137,9 @@ public class TickerFunctionProviderTests : IDisposable
             return Task.CompletedTask;
         };
 
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["TrackFunc"] = ("0 * * * *", TickerTaskPriority.Low, trackingDelegate)
+            ["TrackFunc"] = ("0 * * * *", TickerTaskPriority.Low, trackingDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions);
@@ -165,9 +165,9 @@ public class TickerFunctionProviderTests : IDisposable
     [Fact]
     public void Build_CalledTwice_DoesNotCrashOrLoseData()
     {
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["DoubleFunc"] = ("0 0 1 * *", TickerTaskPriority.Normal, NoOpDelegate)
+            ["DoubleFunc"] = ("0 0 1 * *", TickerTaskPriority.Normal, NoOpDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions);
@@ -186,9 +186,9 @@ public class TickerFunctionProviderTests : IDisposable
     [Fact]
     public void UpdateCronExpressionsFromIConfiguration_UpdatesExpressions()
     {
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["CronFunc"] = ("%CronSettings:Schedule%", TickerTaskPriority.High, NoOpDelegate)
+            ["CronFunc"] = ("%CronSettings:Schedule%", TickerTaskPriority.High, NoOpDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions);
@@ -205,9 +205,9 @@ public class TickerFunctionProviderTests : IDisposable
     [Fact]
     public void UpdateCronExpressionsFromIConfiguration_NoConfigValue_KeepsOriginal()
     {
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["KeepFunc"] = ("%Missing:Key%", TickerTaskPriority.Normal, NoOpDelegate)
+            ["KeepFunc"] = ("%Missing:Key%", TickerTaskPriority.Normal, NoOpDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions);
@@ -228,11 +228,11 @@ public class TickerFunctionProviderTests : IDisposable
     [Fact]
     public void FunctionLookup_AfterBuild_RetrievableByKey()
     {
-        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["Alpha"] = ("0 0 * * *", TickerTaskPriority.High, NoOpDelegate),
-            ["Beta"]  = ("0 0 1 * *", TickerTaskPriority.Low, NoOpDelegate),
-            ["Gamma"] = ("*/10 * * * *", TickerTaskPriority.Normal, NoOpDelegate)
+            ["Alpha"] = ("0 0 * * *", TickerTaskPriority.High, NoOpDelegate, 0),
+            ["Beta"]  = ("0 0 1 * *", TickerTaskPriority.Low, NoOpDelegate, 0),
+            ["Gamma"] = ("*/10 * * * *", TickerTaskPriority.Normal, NoOpDelegate, 0)
         };
 
         TickerFunctionProvider.RegisterFunctions(functions);

--- a/tests/TickerQ.Tests/TickerManagerTests.cs
+++ b/tests/TickerQ.Tests/TickerManagerTests.cs
@@ -48,9 +48,9 @@ public class TickerManagerTests : IDisposable
 
         // Register the test function in TickerFunctionProvider before Build()
         TickerFunctionProvider.RegisterFunctions(
-            new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate)>
+            new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
             {
-                [ValidFunctionName] = ("", TickerTaskPriority.Normal, (_, _, _) => Task.CompletedTask)
+                [ValidFunctionName] = ("", TickerTaskPriority.Normal, (_, _, _) => Task.CompletedTask, 0)
             });
         TickerFunctionProvider.Build();
 

--- a/tests/TickerQ.Tests/TickerQDispatcherConcurrencyTests.cs
+++ b/tests/TickerQ.Tests/TickerQDispatcherConcurrencyTests.cs
@@ -1,0 +1,265 @@
+using NSubstitute;
+using TickerQ.Dispatcher;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Interfaces;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.Tests;
+
+public class TickerQDispatcherConcurrencyTests
+{
+    private readonly ITickerQTaskScheduler _taskScheduler;
+    private readonly ITickerExecutionTaskHandler _taskHandler;
+
+    public TickerQDispatcherConcurrencyTests()
+    {
+        _taskScheduler = Substitute.For<ITickerQTaskScheduler>();
+        _taskHandler = Substitute.For<ITickerExecutionTaskHandler>();
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_WhenConcurrencyGateIsNull()
+    {
+        var act = () => new TickerQDispatcher(_taskScheduler, _taskHandler, null!);
+
+        var ex = Assert.Throws<ArgumentNullException>(act);
+        Assert.Equal("concurrencyGate", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ZeroMaxConcurrency_DoesNotAcquireSemaphore()
+    {
+        var gate = new TickerFunctionConcurrencyGate();
+        var dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, gate);
+
+        Func<CancellationToken, Task>? capturedWork = null;
+        _taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWork = ci.ArgAt<Func<CancellationToken, Task>>(0);
+                return ValueTask.CompletedTask;
+            });
+
+        var context = new InternalFunctionContext
+        {
+            TickerId = Guid.NewGuid(),
+            FunctionName = "Unlimited",
+            CachedPriority = TickerTaskPriority.Normal,
+            CachedMaxConcurrency = 0,
+            TimeTickerChildren = []
+        };
+
+        await dispatcher.DispatchAsync([context]);
+
+        Assert.NotNull(capturedWork);
+        await capturedWork!(CancellationToken.None);
+
+        // No semaphore should have been created for maxConcurrency=0
+        var semaphore = gate.GetSemaphoreOrNull("Unlimited", 0);
+        Assert.Null(semaphore);
+
+        await _taskHandler.Received(1).ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(), false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithMaxConcurrency_AcquiresAndReleasesSemaphore()
+    {
+        var gate = new TickerFunctionConcurrencyGate();
+        var dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, gate);
+
+        Func<CancellationToken, Task>? capturedWork = null;
+        _taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWork = ci.ArgAt<Func<CancellationToken, Task>>(0);
+                return ValueTask.CompletedTask;
+            });
+
+        var context = new InternalFunctionContext
+        {
+            TickerId = Guid.NewGuid(),
+            FunctionName = "Limited",
+            CachedPriority = TickerTaskPriority.Normal,
+            CachedMaxConcurrency = 1,
+            TimeTickerChildren = []
+        };
+
+        await dispatcher.DispatchAsync([context]);
+
+        var semaphore = gate.GetSemaphoreOrNull("Limited", 1);
+        Assert.NotNull(semaphore);
+        Assert.Equal(1, semaphore!.CurrentCount);
+
+        // Execute the work — semaphore should be acquired then released
+        await capturedWork!(CancellationToken.None);
+
+        // After execution completes, semaphore should be released back
+        Assert.Equal(1, semaphore.CurrentCount);
+
+        await _taskHandler.Received(1).ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(), false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithMaxConcurrency_ReleasesSemaphoreOnException()
+    {
+        var gate = new TickerFunctionConcurrencyGate();
+        var dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, gate);
+
+        _taskHandler.ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Task failed"));
+
+        Func<CancellationToken, Task>? capturedWork = null;
+        _taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWork = ci.ArgAt<Func<CancellationToken, Task>>(0);
+                return ValueTask.CompletedTask;
+            });
+
+        var context = new InternalFunctionContext
+        {
+            TickerId = Guid.NewGuid(),
+            FunctionName = "FailingFunc",
+            CachedPriority = TickerTaskPriority.Normal,
+            CachedMaxConcurrency = 1,
+            TimeTickerChildren = []
+        };
+
+        await dispatcher.DispatchAsync([context]);
+
+        var semaphore = gate.GetSemaphoreOrNull("FailingFunc", 1);
+        Assert.Equal(1, semaphore!.CurrentCount);
+
+        // Execute the work — should throw but semaphore must still be released
+        await Assert.ThrowsAsync<InvalidOperationException>(() => capturedWork!(CancellationToken.None));
+
+        // Semaphore must be released even after exception
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_DifferentFunctions_HaveIndependentSemaphores()
+    {
+        var gate = new TickerFunctionConcurrencyGate();
+        var dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, gate);
+
+        var capturedWorks = new List<Func<CancellationToken, Task>>();
+        _taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWorks.Add(ci.ArgAt<Func<CancellationToken, Task>>(0));
+                return ValueTask.CompletedTask;
+            });
+
+        var contexts = new[]
+        {
+            new InternalFunctionContext
+            {
+                TickerId = Guid.NewGuid(),
+                FunctionName = "FuncA",
+                CachedPriority = TickerTaskPriority.Normal,
+                CachedMaxConcurrency = 1,
+                TimeTickerChildren = []
+            },
+            new InternalFunctionContext
+            {
+                TickerId = Guid.NewGuid(),
+                FunctionName = "FuncB",
+                CachedPriority = TickerTaskPriority.Normal,
+                CachedMaxConcurrency = 1,
+                TimeTickerChildren = []
+            }
+        };
+
+        await dispatcher.DispatchAsync(contexts);
+
+        var semaphoreA = gate.GetSemaphoreOrNull("FuncA", 1);
+        var semaphoreB = gate.GetSemaphoreOrNull("FuncB", 1);
+
+        Assert.NotSame(semaphoreA, semaphoreB);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_MaxConcurrencyOne_SerializesExecution()
+    {
+        var gate = new TickerFunctionConcurrencyGate();
+        var dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, gate);
+
+        var capturedWorks = new List<Func<CancellationToken, Task>>();
+        _taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWorks.Add(ci.ArgAt<Func<CancellationToken, Task>>(0));
+                return ValueTask.CompletedTask;
+            });
+
+        var concurrentCount = 0;
+        var maxObserved = 0;
+        var executionOrder = new List<Guid>();
+
+        _taskHandler.ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(async ci =>
+            {
+                var ctx = ci.ArgAt<InternalFunctionContext>(0);
+                var current = Interlocked.Increment(ref concurrentCount);
+                InterlockedMax(ref maxObserved, current);
+                lock (executionOrder) { executionOrder.Add(ctx.TickerId); }
+                await Task.Delay(30);
+                Interlocked.Decrement(ref concurrentCount);
+            });
+
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var id3 = Guid.NewGuid();
+
+        var contexts = new[]
+        {
+            new InternalFunctionContext { TickerId = id1, FunctionName = "Serial", CachedMaxConcurrency = 1, TimeTickerChildren = [] },
+            new InternalFunctionContext { TickerId = id2, FunctionName = "Serial", CachedMaxConcurrency = 1, TimeTickerChildren = [] },
+            new InternalFunctionContext { TickerId = id3, FunctionName = "Serial", CachedMaxConcurrency = 1, TimeTickerChildren = [] }
+        };
+
+        await dispatcher.DispatchAsync(contexts);
+
+        Assert.Equal(3, capturedWorks.Count);
+
+        // Execute all work items concurrently — semaphore should serialize them
+        await Task.WhenAll(capturedWorks.Select(w => Task.Run(() => w(CancellationToken.None))));
+
+        Assert.Equal(1, maxObserved);
+        Assert.Equal(3, executionOrder.Count);
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+            if (value <= current) return;
+        } while (Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+}

--- a/tests/TickerQ.Tests/TickerQDispatcherExtendedTests.cs
+++ b/tests/TickerQ.Tests/TickerQDispatcherExtendedTests.cs
@@ -16,7 +16,7 @@ public class TickerQDispatcherExtendedTests
     {
         _taskScheduler = Substitute.For<ITickerQTaskScheduler>();
         _taskHandler = Substitute.For<ITickerExecutionTaskHandler>();
-        _dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler);
+        _dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, new TickerFunctionConcurrencyGate());
     }
 
     [Fact]

--- a/tests/TickerQ.Tests/TickerQDispatcherTests.cs
+++ b/tests/TickerQ.Tests/TickerQDispatcherTests.cs
@@ -16,13 +16,13 @@ public class TickerQDispatcherTests
     {
         _taskScheduler = Substitute.For<ITickerQTaskScheduler>();
         _taskHandler = Substitute.For<ITickerExecutionTaskHandler>();
-        _dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler);
+        _dispatcher = new TickerQDispatcher(_taskScheduler, _taskHandler, new TickerFunctionConcurrencyGate());
     }
 
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenTaskSchedulerIsNull()
     {
-        var act = () => new TickerQDispatcher(null!, _taskHandler);
+        var act = () => new TickerQDispatcher(null!, _taskHandler, new TickerFunctionConcurrencyGate());
 
         var ex = Assert.Throws<ArgumentNullException>(act);
         Assert.Equal("taskScheduler", ex.ParamName);
@@ -31,7 +31,7 @@ public class TickerQDispatcherTests
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenTaskHandlerIsNull()
     {
-        var act = () => new TickerQDispatcher(_taskScheduler, null!);
+        var act = () => new TickerQDispatcher(_taskScheduler, null!, new TickerFunctionConcurrencyGate());
 
         var ex = Assert.Throws<ArgumentNullException>(act);
         Assert.Equal("taskHandler", ex.ParamName);

--- a/tests/TickerQ.Tests/TickerQFallbackBackgroundServiceTests.cs
+++ b/tests/TickerQ.Tests/TickerQFallbackBackgroundServiceTests.cs
@@ -45,7 +45,8 @@ public class TickerQFallbackBackgroundServiceTests
             _internalManager,
             _schedulerOptions,
             _taskHandler,
-            _taskScheduler);
+            _taskScheduler,
+            new TickerFunctionConcurrencyGate());
     }
 
     [Fact]

--- a/tests/TickerQ.Tests/TickerQSchedulerBackgroundServiceShutdownTests.cs
+++ b/tests/TickerQ.Tests/TickerQSchedulerBackgroundServiceShutdownTests.cs
@@ -41,7 +41,8 @@ public class TickerQSchedulerBackgroundServiceShutdownTests
             _taskHandler,
             _taskScheduler,
             _internalManager,
-            _schedulerOptions);
+            _schedulerOptions,
+            new TickerFunctionConcurrencyGate());
     }
 
     [Fact]

--- a/tests/TickerQ.Tests/TickerQSchedulerBackgroundServiceTests.cs
+++ b/tests/TickerQ.Tests/TickerQSchedulerBackgroundServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using TickerQ.BackgroundServices;
 using TickerQ.Utilities;
+using TickerQ.Utilities.Enums;
 using TickerQ.Utilities.Interfaces;
 using TickerQ.Utilities.Interfaces.Managers;
 using TickerQ.Utilities.Models;
@@ -35,7 +36,8 @@ public class TickerQSchedulerBackgroundServiceTests
             taskHandler,
             taskScheduler,
             internalManager,
-            schedulerOptions);
+            schedulerOptions,
+            new TickerFunctionConcurrencyGate());
 
         using var cts = new CancellationTokenSource();
         var before = DateTime.UtcNow;
@@ -70,6 +72,202 @@ public class TickerQSchedulerBackgroundServiceTests
         Assert.NotNull(task);
 
         return task!;
+    }
+
+    [Fact]
+    public async Task RunScheduler_WithMaxConcurrency_AcquiresAndReleasesSemaphore()
+    {
+        var executionContext = new TickerExecutionContext();
+        var internalManager = Substitute.For<IInternalTickerManager>();
+        var taskHandler = Substitute.For<ITickerExecutionTaskHandler>();
+        var taskScheduler = Substitute.For<ITickerQTaskScheduler>();
+        var gate = new TickerFunctionConcurrencyGate();
+
+        var function = new InternalFunctionContext
+        {
+            TickerId = Guid.NewGuid(),
+            FunctionName = "GatedFunc",
+            CachedPriority = TickerTaskPriority.Normal,
+            CachedMaxConcurrency = 1,
+            TimeTickerChildren = []
+        };
+
+        // First call: return functions to execute, then infinite wait
+        var callCount = 0;
+        internalManager.GetNextTickers(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return (TimeSpan.Zero, new[] { function });
+                return (Timeout.InfiniteTimeSpan, Array.Empty<InternalFunctionContext>());
+            });
+
+        // Pre-set functions so the scheduler finds them on first iteration
+        TickerFunctionProvider.Build();
+        executionContext.SetFunctions([function]);
+
+        Func<CancellationToken, Task>? capturedWork = null;
+        taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWork = ci.ArgAt<Func<CancellationToken, Task>>(0);
+                return ValueTask.CompletedTask;
+            });
+
+        var schedulerOptions = new SchedulerOptionsBuilder
+        {
+            MinPollingInterval = TimeSpan.FromMilliseconds(50)
+        };
+
+        var service = new TickerQSchedulerBackgroundService(
+            executionContext, taskHandler, taskScheduler,
+            internalManager, schedulerOptions, gate);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        try
+        {
+            await InvokeRunSchedulerAsync(service, CancellationToken.None, cts.Token);
+        }
+        catch (OperationCanceledException) { }
+
+        Assert.NotNull(capturedWork);
+
+        // Verify semaphore was created for this function
+        var semaphore = gate.GetSemaphoreOrNull("GatedFunc", 1);
+        Assert.NotNull(semaphore);
+        Assert.Equal(1, semaphore!.CurrentCount);
+
+        // Execute captured work — should acquire and release semaphore
+        await capturedWork!(CancellationToken.None);
+        Assert.Equal(1, semaphore.CurrentCount);
+
+        await taskHandler.Received(1).ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(), false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunScheduler_WithMaxConcurrency_ReleasesSemaphoreOnException()
+    {
+        var executionContext = new TickerExecutionContext();
+        var internalManager = Substitute.For<IInternalTickerManager>();
+        var taskHandler = Substitute.For<ITickerExecutionTaskHandler>();
+        var taskScheduler = Substitute.For<ITickerQTaskScheduler>();
+        var gate = new TickerFunctionConcurrencyGate();
+
+        taskHandler.ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("boom"));
+
+        var function = new InternalFunctionContext
+        {
+            TickerId = Guid.NewGuid(),
+            FunctionName = "FailFunc",
+            CachedPriority = TickerTaskPriority.Normal,
+            CachedMaxConcurrency = 2,
+            TimeTickerChildren = []
+        };
+
+        TickerFunctionProvider.Build();
+        executionContext.SetFunctions([function]);
+
+        internalManager.GetNextTickers(Arg.Any<CancellationToken>())
+            .Returns((Timeout.InfiniteTimeSpan, Array.Empty<InternalFunctionContext>()));
+
+        Func<CancellationToken, Task>? capturedWork = null;
+        taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWork = ci.ArgAt<Func<CancellationToken, Task>>(0);
+                return ValueTask.CompletedTask;
+            });
+
+        var service = new TickerQSchedulerBackgroundService(
+            executionContext, taskHandler, taskScheduler,
+            internalManager, new SchedulerOptionsBuilder(), gate);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        try
+        {
+            await InvokeRunSchedulerAsync(service, CancellationToken.None, cts.Token);
+        }
+        catch (OperationCanceledException) { }
+
+        Assert.NotNull(capturedWork);
+
+        var semaphore = gate.GetSemaphoreOrNull("FailFunc", 2);
+        Assert.Equal(2, semaphore!.CurrentCount);
+
+        // Work should throw, but semaphore must still be released
+        await Assert.ThrowsAsync<InvalidOperationException>(() => capturedWork!(CancellationToken.None));
+        Assert.Equal(2, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task RunScheduler_ZeroMaxConcurrency_NoSemaphoreCreated()
+    {
+        var executionContext = new TickerExecutionContext();
+        var internalManager = Substitute.For<IInternalTickerManager>();
+        var taskHandler = Substitute.For<ITickerExecutionTaskHandler>();
+        var taskScheduler = Substitute.For<ITickerQTaskScheduler>();
+        var gate = new TickerFunctionConcurrencyGate();
+
+        var function = new InternalFunctionContext
+        {
+            TickerId = Guid.NewGuid(),
+            FunctionName = "UnlimitedFunc",
+            CachedPriority = TickerTaskPriority.Normal,
+            CachedMaxConcurrency = 0,
+            TimeTickerChildren = []
+        };
+
+        TickerFunctionProvider.Build();
+        executionContext.SetFunctions([function]);
+
+        internalManager.GetNextTickers(Arg.Any<CancellationToken>())
+            .Returns((Timeout.InfiniteTimeSpan, Array.Empty<InternalFunctionContext>()));
+
+        Func<CancellationToken, Task>? capturedWork = null;
+        taskScheduler.QueueAsync(
+            Arg.Any<Func<CancellationToken, Task>>(),
+            Arg.Any<TickerTaskPriority>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedWork = ci.ArgAt<Func<CancellationToken, Task>>(0);
+                return ValueTask.CompletedTask;
+            });
+
+        var service = new TickerQSchedulerBackgroundService(
+            executionContext, taskHandler, taskScheduler,
+            internalManager, new SchedulerOptionsBuilder(), gate);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        try
+        {
+            await InvokeRunSchedulerAsync(service, CancellationToken.None, cts.Token);
+        }
+        catch (OperationCanceledException) { }
+
+        Assert.NotNull(capturedWork);
+        await capturedWork!(CancellationToken.None);
+
+        // No semaphore should exist for maxConcurrency=0
+        Assert.Null(gate.GetSemaphoreOrNull("UnlimitedFunc", 0));
+
+        await taskHandler.Received(1).ExecuteTaskAsync(
+            Arg.Any<InternalFunctionContext>(), false, Arg.Any<CancellationToken>());
     }
 
     private static async Task<DateTime?> WaitForNextOccurrenceAsync(


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_