### PR TITLE
Sync main → net8

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
+++ b/src/TickerQ.EntityFrameworkCore/Customizer/TickerModelCustomizer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using TickerQ.EntityFrameworkCore.Configurations;
 using TickerQ.Utilities.Entities;
@@ -16,7 +17,15 @@ namespace TickerQ.EntityFrameworkCore.Customizer
 
         public override void Customize(ModelBuilder builder, DbContext context)
         {
-            var schema = context.GetService<TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker>>()?.Schema ?? Constants.DefaultSchema;
+            string schema;
+            try
+            {
+                schema = context.GetService<TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker>>()?.Schema ?? Constants.DefaultSchema;
+            }
+            catch (InvalidOperationException)
+            {
+                schema = Constants.DefaultSchema;
+            }
 
             builder.ApplyConfiguration(new TimeTickerConfigurations<TTimeTicker>(schema));
             builder.ApplyConfiguration(new CronTickerConfigurations<TCronTicker>(schema));

--- a/src/TickerQ.EntityFrameworkCore/DbContextFactory/TickerQDbContext.cs
+++ b/src/TickerQ.EntityFrameworkCore/DbContextFactory/TickerQDbContext.cs
@@ -23,7 +23,15 @@ public class TickerQDbContext<TTimeTicker, TCronTicker> : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        var schema = this.GetService<TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker>>()?.Schema ?? Constants.DefaultSchema;
+        string schema;
+        try
+        {
+            schema = this.GetService<TickerQEfCoreOptionBuilder<TTimeTicker, TCronTicker>>()?.Schema ?? Constants.DefaultSchema;
+        }
+        catch (InvalidOperationException)
+        {
+            schema = Constants.DefaultSchema;
+        }
 
         modelBuilder.ApplyConfiguration(new TimeTickerConfigurations<TTimeTicker>(schema)); 
         modelBuilder.ApplyConfiguration(new CronTickerConfigurations<TCronTicker>(schema)); 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <DotNetVersion>[10.0.0,11.0.0)</DotNetVersion>
+        <DotNetAbstractionsVersion>[8.0.0,)</DotNetAbstractionsVersion>
+    </PropertyGroup>
+
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/tests/TickerQ.EntityFrameworkCore.Tests/Infrastructure/DesignTimeDbContextTests.cs
+++ b/tests/TickerQ.EntityFrameworkCore.Tests/Infrastructure/DesignTimeDbContextTests.cs
@@ -33,6 +33,7 @@ public class DesignTimeDbContextTests : IDisposable
         // Simulate design-time: create DbContext without registering TickerQEfCoreOptionBuilder
         var options = new DbContextOptionsBuilder<TickerQDbContext>()
             .UseSqlite(_connection)
+            .EnableServiceProviderCaching(false)
             .Options;
 
         using var context = new TickerQDbContext(options);
@@ -64,6 +65,7 @@ public class DesignTimeDbContextTests : IDisposable
         var options = new DbContextOptionsBuilder<TickerQDbContext>()
             .UseSqlite(_connection)
             .UseApplicationServiceProvider(serviceProvider)
+            .EnableServiceProviderCaching(false)
             .Options;
 
         using var context = new TickerQDbContext(options);
@@ -80,6 +82,7 @@ public class DesignTimeDbContextTests : IDisposable
         // Verify the full design-time flow: create context → ensure created (simulates migration)
         var options = new DbContextOptionsBuilder<TickerQDbContext>()
             .UseSqlite(_connection)
+            .EnableServiceProviderCaching(false)
             .Options;
 
         using var context = new TickerQDbContext(options);
@@ -101,6 +104,7 @@ public class DesignTimeDbContextTests : IDisposable
         var options = new DbContextOptionsBuilder<CustomAppDbContext>()
             .UseSqlite(_connection)
             .ReplaceService<IModelCustomizer, TickerModelCustomizer<TimeTickerEntity, CronTickerEntity>>()
+            .EnableServiceProviderCaching(false)
             .Options;
 
         using var context = new CustomAppDbContext(options);
@@ -126,6 +130,7 @@ public class DesignTimeDbContextTests : IDisposable
             .UseSqlite(_connection)
             .ReplaceService<IModelCustomizer, TickerModelCustomizer<TimeTickerEntity, CronTickerEntity>>()
             .UseApplicationServiceProvider(serviceProvider)
+            .EnableServiceProviderCaching(false)
             .Options;
 
         using var context = new CustomAppDbContext(options);


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net8`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net8
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_