### PR TITLE
Sync main → net8

### DIFF
--- a/tests/TickerQ.Caching.StackExchangeRedis.Tests/DependencyInjection/PersistenceProviderRegistrationTests.cs
+++ b/tests/TickerQ.Caching.StackExchangeRedis.Tests/DependencyInjection/PersistenceProviderRegistrationTests.cs
@@ -48,16 +48,16 @@ public class PersistenceProviderRegistrationTests
         {
             options.AddStackExchangeRedis(redis =>
             {
-                redis.Configuration = "localhost:6379";
+                redis.Configuration = "localhost:6379,abortConnect=false";
             });
         });
 
-        // Assert
-        var provider = services.BuildServiceProvider();
-        var persistenceProvider = provider.GetService<ITickerPersistenceProvider<TimeTickerEntity, CronTickerEntity>>();
+        // Assert — check service descriptor to avoid requiring a live Redis connection
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(ITickerPersistenceProvider<TimeTickerEntity, CronTickerEntity>));
 
-        Assert.NotNull(persistenceProvider);
-        Assert.Contains("Redis", persistenceProvider.GetType().Name);
+        Assert.NotNull(descriptor);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
     }
 
     [Fact]


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net8`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net8
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_