### PR TITLE
Fix dashboard date formatting by timezone and cron ticker bugs

### DIFF
--- a/src/TickerQ.Caching.StackExchangeRedis/Infrastructure/TickerRedisPersistenceProvider.cs
+++ b/src/TickerQ.Caching.StackExchangeRedis/Infrastructure/TickerRedisPersistenceProvider.cs
@@ -570,7 +570,7 @@ internal sealed class TickerRedisPersistenceProvider<TTimeTicker, TCronTicker> :
             cancellationToken.ThrowIfCancellationRequested();
             if (!Guid.TryParse(redisValue.ToString(), out var id)) continue;
             var cron = await GetAsync<TCronTicker>(CronKey(id)).ConfigureAwait(false);
-            if (cron == null) continue;
+            if (cron == null || !cron.IsEnabled) continue;
             list.Add(new CronTickerEntity
             {
                 Id = cron.Id,

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/cronTickerService.ts
@@ -132,11 +132,12 @@ const runCronTickerOnDemand = () => {
 }
 
 const getTimeTickersGraphDataRange = () => {
+    const timeZoneStore = useTimeZoneStore();
     const baseHttp = useBaseHttpService<object, GetCronTickerGraphDataRangeResponse>('array')
         .FixToResponseModel(GetCronTickerGraphDataRangeResponse, (item) => {
             return {
                 ...item,
-                date: formatDate(item.date, false),
+                date: formatDate(item.date, false, timeZoneStore.effectiveTimeZone),
             }
         });
 
@@ -149,11 +150,12 @@ const getTimeTickersGraphDataRange = () => {
 }
 
 const getTimeTickersGraphDataRangeById = () => {
+    const timeZoneStore = useTimeZoneStore();
     const baseHttp = useBaseHttpService<object, GetCronTickerGraphDataRangeResponse>('array')
         .FixToResponseModel(GetCronTickerGraphDataRangeResponse, (item) => {
             return {
                 ...item,
-                date: formatDate(item.date, false),
+                date: formatDate(item.date, false, timeZoneStore.effectiveTimeZone),
             }
         });
 

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/timeTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/timeTickerService.ts
@@ -157,11 +157,12 @@ const getTimeTickersPaginated = () => {
 }
 
 const getTimeTickersGraphDataRange = () => {
+    const timeZoneStore = useTimeZoneStore();
     const baseHttp = useBaseHttpService<object, GetTimeTickerGraphDataRangeResponse>('array')
         .FixToResponseModel(GetTimeTickerGraphDataRangeResponse, (item) => {
             return {
                 ...item,
-                date: formatDate(item.date, false),
+                date: formatDate(item.date, false, timeZoneStore.effectiveTimeZone),
             }
         });
 

--- a/src/TickerQ.Dashboard/wwwroot/src/main.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/main.ts
@@ -23,6 +23,12 @@ import VueTheMask from 'vue-the-mask'
 // Import styles
 import './assets/main.css'
 
+import { getDateFormatRegion, buildDatePart } from '@/utilities/dateTimeParser'
+import { useTimeZoneStore } from './stores/timeZoneStore'
+
+// Create Pinia store (before Vuetify so the date format function can access the timezone store)
+const pinia = createPinia()
+
 // Create Vuetify instance
 const vuetify = createVuetify({
   components: {
@@ -31,6 +37,18 @@ const vuetify = createVuetify({
     VPullToRefresh
   },
   directives,
+  date: {
+    formats: {
+      keyboardDate: (date: Date) => {
+        const timeZoneStore = useTimeZoneStore(pinia)
+        const region = getDateFormatRegion(timeZoneStore.effectiveTimeZone)
+        const year = String(date.getFullYear())
+        const month = String(date.getMonth() + 1).padStart(2, '0')
+        const day = String(date.getDate()).padStart(2, '0')
+        return buildDatePart(region, year, month, day)
+      },
+    },
+  },
   icons: {
     defaultSet: 'mdi',
     aliases,
@@ -42,9 +60,6 @@ const vuetify = createVuetify({
     defaultTheme: 'dark'
   }
 })
-
-// Create Pinia store
-const pinia = createPinia()
 
 // Create Vue app
 const app = createApp(App)

--- a/src/TickerQ.Dashboard/wwwroot/src/utilities/dateTimeParser.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/utilities/dateTimeParser.ts
@@ -1,5 +1,32 @@
 import { format as timeago } from 'timeago.js';
 
+type DateFormatRegion = 'eu' | 'us' | 'iso';
+
+const europeanZonePrefixes = ['Europe/', 'Africa/'];
+const americanZonePrefixes = ['America/', 'US/'];
+
+export function getDateFormatRegion(timeZone?: string): DateFormatRegion {
+    if (!timeZone) return 'iso';
+
+    if (europeanZonePrefixes.some(prefix => timeZone.startsWith(prefix))) {
+        return 'eu';
+    }
+
+    if (americanZonePrefixes.some(prefix => timeZone.startsWith(prefix))) {
+        return 'us';
+    }
+
+    return 'iso';
+}
+
+export function buildDatePart(region: DateFormatRegion, year: string, month: string, day: string): string {
+    switch (region) {
+        case 'eu': return `${day}/${month}/${year}`;
+        case 'us': return `${month}/${day}/${year}`;
+        default:   return `${year}-${month}-${day}`;
+    }
+}
+
 export function formatDate(
     utcDateString: string,
     includeTime = true,
@@ -31,12 +58,13 @@ export function formatDate(
         options.hour12 = false;
     }
 
-    // Use formatToParts for a consistent, locale-independent YYYY-MM-DD HH:mm:ss format
     const formatter = new Intl.DateTimeFormat('en-CA', options);
     const parts = formatter.formatToParts(dateObj);
     const get = (type: string) => parts.find(p => p.type === type)?.value ?? '';
 
-    const datePart = `${get('year')}-${get('month')}-${get('day')}`;
+    const region = getDateFormatRegion(timeZone);
+    const datePart = buildDatePart(region, get('year'), get('month'), get('day'));
+
     if (!includeTime) {
         return datePart;
     }

--- a/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/CronTicker.vue
@@ -493,7 +493,7 @@ const onSubmitToggleConfirmDialog = async () => {
     const id = toggleConfirmDialog.propData?.id!
     const isEnabled = toggleConfirmDialog.propData?.isEnabled!
     toggleConfirmDialog.close()
-    await toggleCronTicker.requestAsync(id, isEnabled)
+    await toggleCronTicker.requestAsync(id, !isEnabled)
     await loadPageData()
   } catch (error: any) {
     if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
@@ -1261,7 +1261,7 @@ const refreshData = async () => {
                     <template v-slot:activator="{ props }">
                       <button
                         v-bind="props"
-                        @click="ToggleCronTickerEnabled(item.id, !item.isEnabled)"
+                        @click="ToggleCronTickerEnabled(item.id, item.isEnabled)"
                         class="modern-action-btn"
                         :class="item.isEnabled ? 'disable-btn' : 'enable-btn'"
                       >

--- a/src/TickerQ.Dashboard/wwwroot/src/views/TimeTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/TimeTicker.vue
@@ -1275,7 +1275,7 @@ const canBeForceDeleted = ref<string[]>([])
             <template v-slot:item.lockHolder="{ item }">
               <span class="text-caption">{{ item.lockHolder }}</span>
               <v-tooltip v-if="item.lockHolder != ''" activator="parent" location="left">
-                <span>Locked At: {{ formatDate(item.lockedAt) }}</span>
+                <span>Locked At: {{ formatDate(item.lockedAt, true, timeZoneStore.effectiveTimeZone) }}</span>
               </v-tooltip>
             </template>
 


### PR DESCRIPTION
## Summary
- **Timezone-aware date formatting**: Dates now display in the format matching the selected timezone region — `dd/MM/yyyy` for European zones, `MM/dd/yyyy` for American zones, `yyyy-MM-dd` (ISO) for all others (UTC, Asia, Australia)
- **Date picker format**: Vuetify `v-date-input` components also respect the timezone-based format via a custom `keyboardDate` format function
- **Fix cron ticker toggle dialog**: Enable/Disable confirmation dialog was showing inverted text (clicking Disable showed "Enable" and vice versa)
- **Fix Redis disabled cron tickers**: `GetAllCronTickerExpressions` in the Redis persistence provider was not filtering out disabled cron tickers, causing them to keep generating occurrences after being disabled from the dashboard

## Test plan
- [ ] Select a European timezone (e.g. `Europe/Berlin`) — verify all dates show as `dd/MM/yyyy`
- [ ] Select an American timezone (e.g. `America/New_York`) — verify all dates show as `MM/dd/yyyy`
- [ ] Select UTC — verify dates show as `yyyy-MM-dd`
- [ ] Open Add Time Ticker dialog — verify date picker uses the correct format
- [ ] Click Enable/Disable on a cron ticker — verify dialog text matches the intended action
- [ ] With Redis persistence: disable a cron ticker and verify it stops generating new occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)