### PR TITLE
Sync main → net8

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
         <PackageTags>ticker;queue;cron;time;scheduler;fire-and-forget</PackageTags>
         <PackageIcon>icon.jpg</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>8.2.0</Version>
+        <Version>8.2.1</Version>
         <DotNetVersion>[8.0.0,9.0.0)</DotNetVersion>
         <DotNetAbstractionsVersion>[8.0.0,)</DotNetAbstractionsVersion>
         <LangVersion>default</LangVersion>


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net8`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net8
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_