### PR TITLE
Sync main → net9

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
         <PackageTags>ticker;queue;cron;time;scheduler;fire-and-forget</PackageTags>
         <PackageIcon>icon.jpg</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>9.2.1</Version>
+        <Version>9.2.2</Version>
         <DotNetVersion>[9.0.0,10.0.0)</DotNetVersion>
         <DotNetAbstractionsVersion>[10.0.0,11.0.0)</DotNetAbstractionsVersion>
         <LangVersion>default</LangVersion>

--- a/src/TickerQ.EntityFrameworkCore/Customizer/CustomizerServiceDescriptor.cs
+++ b/src/TickerQ.EntityFrameworkCore/Customizer/CustomizerServiceDescriptor.cs
@@ -42,6 +42,7 @@ public static class ServiceBuilder
                 optionsBuilder.UseApplicationServiceProvider(sp);
                 return new PooledDbContextFactory<TContext>(optionsBuilder.Options, builder.PoolSize);
             });
+            services.TryAddScoped<TContext>(sp => sp.GetRequiredService<IDbContextFactory<TContext>>().CreateDbContext());
             services.AddSingleton<ITickerPersistenceProvider<TTimeTicker, TCronTicker>, TickerEfCorePersistenceProvider<TContext, TTimeTicker, TCronTicker>>();
         };
     }


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_