### PR TITLE
Add CLA workflow and contributing guidelines

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'pull_request_target' && github.event.action != 'closed') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/Arcenox-co/TickerQ/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot]'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,43 @@
+# TickerQ Contributor License Agreement
+
+Thank you for your interest in contributing to TickerQ, owned and maintained by Arcenox ("Company", "we", "us"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the Company.
+
+By submitting a Contribution to any repository owned by the Company, you accept and agree to the following terms and conditions.
+
+## 1. Definitions
+
+**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that you intentionally submit to the Company for inclusion in TickerQ. "Submit" means any form of electronic communication sent to the Company, including but not limited to pull requests, issues, commits, and comments on GitHub.
+
+**"You" (or "Your")** means the individual or legal entity making the Contribution. For legal entities, the entity making the Contribution and all entities that control, are controlled by, or are under common control with that entity are considered a single Contributor.
+
+## 2. Grant of Copyright License
+
+You hereby grant to the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and any derivative works thereof. This includes the right to use Your Contributions under any license, including proprietary licenses.
+
+## 3. Grant of Patent License
+
+You hereby grant to the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Your Contributions, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the project to which it was submitted.
+
+## 4. Right to Grant Licenses
+
+You represent that:
+
+- You are legally entitled to grant the above licenses.
+- If your employer has rights to intellectual property that you create, you represent that you have received permission to make Contributions on behalf of that employer, or that your employer has waived such rights for your Contributions to TickerQ.
+- Each of Your Contributions is Your original creation. If any part of Your Contribution is not Your original creation, you will clearly identify it, including the source and any applicable license restrictions.
+
+## 5. No Obligation
+
+You understand that the decision to include Your Contribution in any project or product is entirely at the Company's discretion. The Company is under no obligation to use Your Contribution.
+
+## 6. Support and Warranty Disclaimer
+
+Your Contributions are provided on an "AS IS" basis, without warranties or conditions of any kind, either express or implied, including without limitation any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose. You are not expected to provide support for Your Contributions.
+
+## 7. Notification
+
+You agree to notify the Company of any facts or circumstances of which you become aware that would make the representations in this Agreement inaccurate.
+
+---
+
+**By signing this Agreement via CLA Assistant, you acknowledge that you have read, understood, and agree to be bound by the terms above.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to TickerQ
+
+We welcome contributions to TickerQ! Before you start, please read through this guide.
+
+## Contributor License Agreement (CLA)
+
+All contributors must sign our [Contributor License Agreement](CLA.md) before their pull request can be merged. This is a one-time process handled automatically via [CLA Assistant](https://cla-assistant.io/) when you open your first pull request.
+
+**Why?** TickerQ is dual-licensed under Apache 2.0 and MIT. The CLA ensures that all contributions can be distributed under these licenses and that the project can continue to evolve.
+
+## How to Contribute
+
+1. **Fork** the repository
+2. **Create a branch** from `main` for your changes
+3. **Make your changes** and ensure the build passes
+4. **Open a pull request** against `main`
+5. **Sign the CLA** when prompted by the CLA Assistant bot
+
+## Development Setup
+
+### Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) (or .NET 8/9 depending on your target)
+- PostgreSQL, SQL Server, SQLite, or MySQL (for integration tests)
+- [Node.js 18+](https://nodejs.org/) (for the Node.js SDK)
+
+### Building
+
+```bash
+dotnet build src/src.sln
+```
+
+### Running Tests
+
+```bash
+dotnet test src/src.sln
+```
+
+## Guidelines
+
+- Follow existing code style and conventions
+- Add tests for new functionality
+- Keep pull requests focused — one feature or fix per PR
+- Write clear commit messages
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/Arcenox-co/TickerQ/issues) to report bugs or request features. Include steps to reproduce, expected behavior, and actual behavior.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [dual license (Apache 2.0 / MIT)](LICENSE), subject to the terms of the [CLA](CLA.md).


### PR DESCRIPTION
## Summary
- Add `CLA.md` — Contributor License Agreement covering copyright/patent grants, aligned with the project's dual Apache 2.0 / MIT license
- Add `CONTRIBUTING.md` — Development setup, contribution process, and CLA requirement
- Add `.github/workflows/cla.yml` — Automated CLA check on PRs using `contributor-assistant/github-action`

## Setup required after merge
1. Create a **`CLA_TOKEN`** repository secret (Settings > Secrets) — a PAT with `repo` scope to store signatures
2. Optionally create a **public gist** with the CLA text and update `path-to-document` in the workflow
3. Add `license/cla` as a **required status check** on the `main` branch protection rule

## Test plan
- [ ] Merge PR and verify CLA workflow triggers on a test PR from a fork
- [ ] Verify bot comments with CLA signing prompt on unsigned PRs
- [ ] Verify allowlisted bots (dependabot, github-actions, renovate) bypass CLA check

🤖 Generated with [Claude Code](https://claude.com/claude-code)