### PR TITLE
Fix dashboard WebSocket 405 when host uses MapStaticAssets

### DIFF
--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using TickerQ.Dashboard.Infrastructure;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Routing;
 using TickerQ.Utilities.Entities;
 
 namespace TickerQ.Dashboard.DependencyInjection
@@ -343,6 +344,15 @@ namespace TickerQ.Dashboard.DependencyInjection
                     // Mirror Map() behavior: move the matched segment from Path to PathBase
                     context.Request.PathBase = originalPathBase.Add(matchedPath);
                     context.Request.Path = remainingPath;
+
+                    // Clear any endpoint matched by host-level routing so the branch's
+                    // own UseRouting() re-evaluates against dashboard endpoints.
+                    // Without this, host Map*() calls (e.g. MapStaticAssets().ShortCircuit())
+                    // can cause the branch's routing middleware to skip evaluation — the
+                    // EndpointRoutingMiddleware short-circuits when GetEndpoint() is non-null.
+                    // This results in 405 responses for SignalR/WebSocket requests (#456).
+                    context.SetEndpoint(null);
+                    context.Request.RouteValues?.Clear();
 
                     try
                     {

--- a/tests/TickerQ.Tests/DashboardPathBaseTests.cs
+++ b/tests/TickerQ.Tests/DashboardPathBaseTests.cs
@@ -3,7 +3,9 @@ using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TickerQ.Dashboard.DependencyInjection;
 
@@ -269,6 +271,128 @@ public class DashboardPathBaseTests
             .StartAsync();
 
         return host;
+    }
+
+    #endregion
+
+    #region MapPathBaseAware — endpoint routing coexistence (issue #456)
+
+    [Fact]
+    public async Task MapPathBaseAware_ClearsHostEndpoint_SoBranchRoutingCanReevaluate()
+    {
+        // Simulates the scenario in issue #456: host-level routing (e.g. MapStaticAssets)
+        // sets an endpoint before the dashboard branch runs. The branch must clear it so
+        // its own UseRouting() re-evaluates against dashboard endpoints.
+        var mapMethod = typeof(ServiceCollectionExtensions).GetMethod(
+            "MapPathBaseAware",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                });
+                webBuilder.Configure(app =>
+                {
+                    // Simulate host-level routing setting an endpoint (like MapStaticAssets does)
+                    app.Use(async (context, next) =>
+                    {
+                        var dummyEndpoint = new Endpoint(
+                            _ => Task.CompletedTask,
+                            new EndpointMetadataCollection(),
+                            "DummyHostEndpoint");
+                        context.SetEndpoint(dummyEndpoint);
+                        context.Request.RouteValues["dummy"] = "value";
+                        await next();
+                    });
+
+                    var configuration = new Action<IApplicationBuilder>(branch =>
+                    {
+                        branch.Run(async context =>
+                        {
+                            // Verify endpoint was cleared inside the branch
+                            var endpoint = context.GetEndpoint();
+                            var hasRouteValues = context.Request.RouteValues.Count > 0;
+                            await context.Response.WriteAsync(
+                                endpoint == null && !hasRouteValues ? "cleared" : "not-cleared");
+                        });
+                    });
+
+                    mapMethod.Invoke(null, new object[] { app, "/dashboard", configuration });
+
+                    app.Run(async context =>
+                    {
+                        await context.Response.WriteAsync("fallthrough");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = host.GetTestClient();
+        var response = await client.GetAsync("/dashboard/test");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("cleared", body);
+    }
+
+    [Fact]
+    public async Task MapPathBaseAware_WithHostEndpoint_NonMatchingPath_PreservesEndpoint()
+    {
+        // Non-matching paths should pass through without clearing the host endpoint
+        var mapMethod = typeof(ServiceCollectionExtensions).GetMethod(
+            "MapPathBaseAware",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                });
+                webBuilder.Configure(app =>
+                {
+                    app.Use(async (context, next) =>
+                    {
+                        var dummyEndpoint = new Endpoint(
+                            _ => Task.CompletedTask,
+                            new EndpointMetadataCollection(),
+                            "DummyHostEndpoint");
+                        context.SetEndpoint(dummyEndpoint);
+                        await next();
+                    });
+
+                    var configuration = new Action<IApplicationBuilder>(branch =>
+                    {
+                        branch.Run(async context =>
+                        {
+                            await context.Response.WriteAsync("branch-hit");
+                        });
+                    });
+
+                    mapMethod.Invoke(null, new object[] { app, "/dashboard", configuration });
+
+                    app.Run(async context =>
+                    {
+                        var endpoint = context.GetEndpoint();
+                        await context.Response.WriteAsync(
+                            endpoint?.DisplayName == "DummyHostEndpoint" ? "preserved" : "lost");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = host.GetTestClient();
+        var response = await client.GetAsync("/other/path");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("preserved", body);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- Fixes #456: Dashboard WebSocket/SignalR connections return HTTP 405 when the host application uses `MapStaticAssets().ShortCircuit()` (or other `Map*()` calls that activate endpoint routing)
- Root cause: ASP.NET Core's `EndpointRoutingMiddleware` skips route evaluation when `GetEndpoint()` is non-null. Host-level `Map*()` calls can set an endpoint on the `HttpContext` before the dashboard's branched pipeline runs. The branch's own `UseRouting()` then skips evaluation, so SignalR negotiate/WebSocket requests hit the wrong (host) endpoint → 405
- Fix: Call `SetEndpoint(null)` and clear `RouteValues` in `MapPathBaseAware` before entering the branch, ensuring the branch's routing middleware re-evaluates against dashboard endpoints

## Changes

- `src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs`: Reset endpoint routing state in `MapPathBaseAware` when the dashboard base path matches
- `tests/TickerQ.Tests/DashboardPathBaseTests.cs`: Add 2 integration tests verifying endpoint is cleared inside the branch and preserved for non-matching paths

## Test plan

- [x] New test: `MapPathBaseAware_ClearsHostEndpoint_SoBranchRoutingCanReevaluate` — verifies endpoint and route values are cleared inside the branch when host-level routing set an endpoint
- [x] New test: `MapPathBaseAware_WithHostEndpoint_NonMatchingPath_PreservesEndpoint` — verifies non-matching paths preserve the host endpoint (no unintended side effects)
- [x] All 17 existing `DashboardPathBaseTests` pass (no regressions)
- [x] Full test suite: 486/487 pass (1 pre-existing timing flake in `RestartThrottleManagerTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)