### PR TITLE
Sync main → net8

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,33 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+    branches: [main]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'pull_request_target' && github.event.action != 'closed') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/Arcenox-co/TickerQ/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: 'dependabot[bot],github-actions[bot],renovate[bot]'


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net8`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net8
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_