### PR TITLE
chore: CLA signing (do not merge)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,43 @@
+# Contributors
+
+Thank you to everyone who has contributed to TickerQ!
+
+## Core
+
+| Name | GitHub | Contributions |
+|------|--------|--------------|
+| Albert Kunushevci | [@arcenox](https://github.com/arcenox) | Creator and maintainer |
+
+## Contributors
+
+| Name | GitHub | Contributions |
+|------|--------|--------------|
+| Ingmar Olmaru | [@Kedireng](https://github.com/Kedireng) | ApplicationDbContext support, EF Core customizer, DbContext factory |
+| Steve Wojciechowski | [@stevewoj](https://github.com/stevewoj) | TimeTickerEntity JSON tracking fields, host authorization fix, JsonExampleGenerator fix |
+| Wojciech Wentland | [@desty2k](https://github.com/desty2k) | Thread-safety fixes, resource leak fixes, SafeCancellationTokenSource, CronScheduleCache |
+| Daniel Nordström | [@SpaceOgre](https://github.com/SpaceOgre) | Retry logic, enable/disable background services, schema assignment |
+| Doruk Akin | [@PuFGGs](https://github.com/PuFGGs) | TimeTicker cancellation support, dashboard UI enhancements |
+| Rafael Câmara | [@RafaelJCamara](https://github.com/RafaelJCamara) | Dashboard pagination, tooltips, authentication sample, PR workflow |
+| Aryan Riyahi | [@aryanriyahi](https://github.com/aryanriyahi) | Test infrastructure, project configuration |
+| jods | [@jods4](https://github.com/jods4) | Dashboard authentication fixes, configurable auth policy |
+| Cédric Luthi | [@0xced](https://github.com/cedric-luthi) | Multi-target .NET 8/9 support, CI pipeline improvements |
+| Ryan Esteves | [@snargledorf](https://github.com/snargledorf) | Dashboard cron ticker occurrence dialog, cron ticker service |
+| Arthur Yershov | [@Arthur9205](https://github.com/Arthur9205) | Configurable EF Core schema override |
+| EarlJester | [@EarlJester](https://github.com/EarlJester) | Remove ASP.NET Core dependency from TickerQ.Utilities |
+| Emrul Kayes | [@mdemrulkayes](https://github.com/mdemrulkayes) | TimeTicker delete behavior, seed ticker methods |
+| Igor Solomatov | [@isolomatov-gd](https://github.com/isolomatov-gd) | CronTickerOccurrence duplicate key fix |
+| Anton Roos | [@antonroos](https://github.com/antonroos) | Initial documentation |
+| Ugochukwu Mmaduekwe | [@ugo4brain](https://github.com/ugo4brain) | Early contributions and testing |
+| ESANJU BABATUNDE | [@TEESOFTTECH](https://github.com/TEESOFTTECH) | Dashboard cron ticker UI improvements |
+| Alano | [@Alano13](https://github.com/Alano13) | README typo fixes |
+| Eric Williams | [@ewilliams0305](https://github.com/ewilliams0305) | README manual start example |
+| Ricardo Escobar | [@REscobar](https://github.com/REscobar) | Ticker request allocation optimizations |
+| Cédric Hulin | [@cedric-hulin](https://github.com/hulin-cedric) | Source generator namespace conflict fix |
+| Vitaliy Pomozov | [@v-pomozov](https://github.com/v-pomozov) | Authorization with roles fix |
+| Jaco Kok | [@kokjaco](https://github.com/kokjaco) | Dashboard styling fix |
+| Denis Balan | [@DenisBalan](https://github.com/DenisBalan) | Bug fixes |
+| Thogsit | [@Thogsit](https://github.com/Thogsit) | Bug fixes |
+| pnguyen535 | [@pnguyen535](https://github.com/pnguyen535) | TickerClock UTC fix |
+| zetroot | [@zetroot](https://github.com/zetroot) | Source generator pragma suppression |
+| neo.zhu | [@neozhu](https://github.com/neozhu) | Bug fixes |
+| jova1971 | [@jova1971](https://github.com/jova1971) | Bug fixes |

--- a/README.md
+++ b/README.md
@@ -184,3 +184,4 @@ PRs, ideas, and issues are welcome!
 
 **MIT OR Apache 2.0** © [Arcenox](https://arcenox.com)  
 You may choose either license to use this software.
+

--- a/README.md
+++ b/README.md
@@ -172,11 +172,15 @@ We want to acknowledge the individuals and organizations who support the develop
 
 ## 🤝 Contribution
 
-PRs, ideas, and issues are welcome!
+PRs, ideas, and issues are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) and sign the [CLA](CLA.md) before submitting a pull request.
 
-1. Fork & branch
-2. Code your change
-3. Submit a Pull Request
+## Contributors
+
+Thanks to all our wonderful contributors! See [CONTRIBUTORS.md](CONTRIBUTORS.md) for details.
+
+<a href="https://github.com/Arcenox-co/TickerQ/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Arcenox-co/TickerQ" />
+</a>
 
 ---
 


### PR DESCRIPTION
## CLA Signing PR

This PR exists solely for contributors to sign the [Contributor License Agreement](https://github.com/Arcenox-co/TickerQ/blob/main/CLA.md).

**This PR will not be merged.** It will be closed once all contributors have signed.

### How to sign

Comment on this PR with the following text:

> I have read the CLA Document and I hereby sign the CLA

That's it — one comment, one time, and you're done for all future contributions.

### Why?

TickerQ is dual-licensed under Apache 2.0 and MIT. The CLA ensures all contributions can continue to be distributed under these licenses. [Read the full CLA here](https://github.com/Arcenox-co/TickerQ/blob/main/CLA.md).

cc @Kedireng @stevewoj @desty2k @SpaceOgre @PuFGGs @jods4 @RafaelJCamara