### PR TITLE
Sync main → net9

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
 # TickerQ Contributor License Agreement
 
-Thank you for your interest in contributing to TickerQ, owned and maintained by Arcenox ("Company", "we", "us"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the Company.
+Thank you for your interest in contributing to TickerQ, owned and maintained by Arcenox LLC ("Company", "we", "us"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the Company.
 
 By submitting a Contribution to any repository owned by the Company, you accept and agree to the following terms and conditions.
 

--- a/LICENSE
+++ b/LICENSE
@@ -174,7 +174,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-Copyright 2025 Arcenox
+Copyright 2025-present Arcenox LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -192,22 +192,22 @@ limitations under the License.
 
                                  MIT License
 
-Copyright (c) 2025 Arcenox
+Copyright (c) 2025-present Arcenox LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights  
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell  
-copies of the Software, and to permit persons to whom the Software is  
-furnished to do so, subject to the following conditions:  
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all  
-copies or substantial portions of the Software.  
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER  
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,65 @@
-
-<h1 align="center">TickerQ</h1>
+<h1 align="center">
+  <img src="https://tickerq.net/tickerq-logo.png" alt="TickerQ Logo" width="140" />
+  <br />
+  TickerQ
+</h1>
 
 <p align="center">
-  <img src="https://tickerq.net/tickerq-logo.png" alt="TickerQ Logo" width="200" />
+  <strong>The modern job scheduler for .NET</strong><br />
+  Source-generated task scheduling with built-in persistence, cron & time-based execution, and real-time monitoring.
 </p>
 
+<p align="center">
+  <a href="https://www.nuget.org/packages/tickerq"><img src="https://img.shields.io/nuget/dt/tickerq.svg?style=flat-square" alt="NuGet Downloads" /></a>
+  <a href="https://www.nuget.org/packages/tickerq"><img src="https://img.shields.io/nuget/vpre/tickerq.svg?style=flat-square" alt="NuGet Version" /></a>
+  <a href="https://github.com/Arcenox-co/TickerQ/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/Arcenox-co/TickerQ/build.yml?branch=main&style=flat-square" alt="Build Status" /></a>
+  <a href="https://tickerq.arcenox.com"><img src="https://img.shields.io/badge/docs-tickerq.net-blue?style=flat-square" alt="Documentation" /></a>
+  <a href="https://discord.gg/ZJemWvp9MK"><img src="https://img.shields.io/badge/discord-TickerQ-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://opencollective.com/tickerq"><img src="https://opencollective.com/tickerq/tiers/badge.svg?style=flat-square" alt="OpenCollective" /></a>
+</p>
 
-[![Discord Community](https://img.shields.io/badge/Discord-TickerQ-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/ZJemWvp9MK)
-
-
-[![NuGet](https://img.shields.io/nuget/dt/tickerq.svg)](https://www.nuget.org/packages/tickerq) 
-[![NuGet](https://img.shields.io/nuget/vpre/tickerq.svg)](https://www.nuget.org/packages/tickerq)
-[![Build NuGet Packages](https://github.com/Arcenox-co/TickerQ/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/Arcenox-co/TickerQ/actions/workflows/build.yml)
-[![Documentation](https://img.shields.io/badge/docs%20-official%20web-blue)](https://tickerq.arcenox.com)
-[![](https://opencollective.com/tickerq/tiers/badge.svg)](https://opencollective.com/tickerq)
-
-**Robust. Adaptive. Precise.**  
-TickerQ is a fast, reflection-free background task scheduler for .NET — built with source generators, EF Core integration, cron + time-based execution, and a real-time dashboard.
-
-### 📚 [Full Docs: https://tickerq.net](https://tickerq.net)
-(Docs are open-source and anyone can help us improving [Documentation Repository](https://github.com/Arcenox-co/TickerQ-UI)
-
-### 🚀 [TickerQ Hub: https://hub.tickerq.net](https://hub.tickerq.net)
-TickerQ Hub is the mission control for distributed scheduling. It connects all your applications through SDKs, keeps execution in your own infrastructure, and gives you a single dashboard to manage nodes, environments, credentials, and functions. One Hub, total visibility, zero lock-in.
-
-> **Note:**
-All TickerQ packages are versioned together — even if a package has no changes — to keep the ecosystem in sync. Always update all packages to the same version.
-
-> **Important:** The entire 2.* package line is deprecated, considered legacy, and is no longer maintained. For all current and future development, use the .NET 8+ versions of TickerQ.
 ---
 
-## ✨ Features
+## Why TickerQ?
 
-- Time and cron scheduling for one-off and recurring jobs
-- Reflection-free core with source-generated job handlers
-- EF Core persistence for jobs, state, and history
-- Live Dashboard UI - [View Screenshots](https://tickerq.net/features/dashboard.html#dashboard-screenshots)
-- Retry policies & throttling for robust execution
-- First-class dependency injection support
-- Multi-node distributed coordination (via Redis heartbeats and dead-node cleanup)
----
+| | |
+|---|---|
+| **Zero reflection, AOT ready** | Source generators at compile time. No runtime reflection, no magic strings, fully trimmable. |
+| **Your database** | EF Core (PostgreSQL, SQL Server, SQLite, MySQL) or Redis. No separate storage. |
+| **Real-time dashboard** | Built-in SignalR dashboard. Monitor, inspect, manage — no paid add-ons. |
+| **Multi-node** | Redis heartbeats, dead-node cleanup, lock-based coordination. Just add instances. |
+| **Minimal setup** | `AddTickerQ()` → decorate a method → schedule. Minutes, not hours. |
 
-# Quick Start
+## Features
 
-Get up and running with TickerQ in under 5 minutes.
+- **Time & cron scheduling** — one-off and recurring jobs
+- **Source-generated** — compile-time function registration for maximum performance
+- **Dual persistence** — EF Core (PostgreSQL, SQL Server, SQLite, MySQL) or Redis
+- **Live dashboard** — real-time UI with SignalR — [screenshots](https://tickerq.net/features/dashboard.html#dashboard-screenshots)
+- **Retry & throttling** — configurable retry policies with backoff
+- **Dependency injection** — first-class DI support
+- **Multi-node** — distributed coordination via Redis heartbeats and dead-node cleanup
+- **Hub** — centralized scheduling across applications via [TickerQ Hub](https://hub.tickerq.net)
 
-## Prerequisites
-
-- .NET 8.0 or later
-- A .NET project (Console, Web API, or ASP.NET Core)
-
-## Step 1: Install TickerQ
+## Quick Start
 
 ```bash
 dotnet add package TickerQ
 ```
 
-## Step 2: Register Services
-
-Add TickerQ to your `Program.cs`:
+### 1. Register services
 
 ```csharp
-using TickerQ.DependencyInjection;
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddTickerQ();
 
 var app = builder.Build();
-app.UseTickerQ(); // Activate job processor
+app.UseTickerQ();
 app.Run();
 ```
 
-## Step 3: Create a Job Function
-
-Create a job function with the `[TickerFunction]` attribute:
+### 2. Create a job
 
 ```csharp
 using TickerQ.Utilities.Base;
@@ -87,100 +72,66 @@ public class MyJobs
         CancellationToken cancellationToken)
     {
         Console.WriteLine($"Hello from TickerQ! Job ID: {context.Id}");
-        Console.WriteLine($"Scheduled at: {DateTime.UtcNow:HH:mm:ss}");
     }
 }
 ```
 
-## Step 4: Schedule the Job
-
-Inject the manager and schedule your job:
+### 3. Schedule it
 
 ```csharp
-using TickerQ.Utilities.Entities;
-using TickerQ.Utilities.Interfaces.Managers;
-
-public class MyService
+public class MyService(ITimeTickerManager<TimeTickerEntity> manager)
 {
-    private readonly ITimeTickerManager<TimeTickerEntity> _timeTickerManager;
-    
-    public MyService(ITimeTickerManager<TimeTickerEntity> timeTickerManager)
+    public async Task Schedule()
     {
-        _timeTickerManager = timeTickerManager;
-    }
-    
-    public async Task ScheduleJob()
-    {
-        var result = await _timeTickerManager.AddAsync(new TimeTickerEntity
+        await manager.AddAsync(new TimeTickerEntity
         {
             Function = "HelloWorld",
-            ExecutionTime = DateTime.UtcNow.AddSeconds(10) // Run in 10 seconds
+            ExecutionTime = DateTime.UtcNow.AddSeconds(10)
         });
-        
-        if (result.IsSucceeded)
-        {
-            Console.WriteLine($"Job scheduled! ID: {result.Result.Id}");
-        }
     }
 }
 ```
 
-## Step 5: Run Your Application
+## Packages
 
-```bash
-dotnet run
-```
+| Package | Description |
+|---------|------------|
+| [`TickerQ`](https://www.nuget.org/packages/TickerQ) | Core scheduler engine |
+| [`TickerQ.Utilities`](https://www.nuget.org/packages/TickerQ.Utilities) | Shared types, entities, and interfaces |
+| [`TickerQ.EntityFrameworkCore`](https://www.nuget.org/packages/TickerQ.EntityFrameworkCore) | EF Core persistence provider |
+| [`TickerQ.Caching.StackExchangeRedis`](https://www.nuget.org/packages/TickerQ.Caching.StackExchangeRedis) | Redis persistence and distributed coordination |
+| [`TickerQ.Dashboard`](https://www.nuget.org/packages/TickerQ.Dashboard) | Real-time dashboard UI |
+| [`TickerQ.Instrumentation.OpenTelemetry`](https://www.nuget.org/packages/TickerQ.Instrumentation.OpenTelemetry) | OpenTelemetry tracing |
+| [`TickerQ.SourceGenerator`](https://www.nuget.org/packages/TickerQ.SourceGenerator) | Compile-time function registration |
 
-Wait 10 seconds and you should see:
-```
-Job scheduled! ID: {guid}
-Hello from TickerQ! Job ID: {guid}
-Scheduled at: {time}
-```
+> **Note:** All packages are versioned together. Always update all packages to the same version.
 
----
+## TickerQ Hub
 
-## 💖 Sponsors & Backers
+Centralized scheduling across applications — [hub.tickerq.net](https://hub.tickerq.net)
 
-We want to acknowledge the individuals and organizations who support the development of TickerQ through [OpenCollective](https://opencollective.com/tickerq). Your contributions help us maintain and grow this project. If you'd like to support, check out the tiers below and join the community!
+## Documentation
 
+Full documentation at **[tickerq.net](https://tickerq.net)** — docs are open-source at [TickerQ-UI](https://github.com/Arcenox-co/TickerQ-UI).
 
-[Become a Sponsor or Backer on OpenCollective](https://opencollective.com/tickerq)
+## Sponsors & Backers
 
----
+Support TickerQ through [OpenCollective](https://opencollective.com/tickerq).
 
-### 🏆 Gold Sponsors
-*Become a gold sponsor and get your logo here with a link to your site.*
+<a href="https://opencollective.com/tickerq"><img src="https://opencollective.com/tickerq/backers.svg?width=890" /></a>
 
----
+## Contributing
 
-### 🥈 Silver Sponsors
-*Become a silver sponsor and get your logo here with a link to your site.*
+PRs, ideas, and issues are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) and sign the [CLA](CLA.md) before submitting a pull request.
 
----
+## Contributors
 
-### 🥉 Bronze Sponsors
-*Become a bronze sponsor and get your logo here with a link to your site.*
+Thanks to all our wonderful contributors! See [CONTRIBUTORS.md](CONTRIBUTORS.md) for details.
 
----
+<a href="https://github.com/Arcenox-co/TickerQ/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Arcenox-co/TickerQ" />
+</a>
 
-### 🙌 Backers
-[Become a backer](https://opencollective.com/tickerq#backer) and get your image on our README on GitHub with a link to your site.
+## License
 
-<a href="https://opencollective.com/tickerq/backer/0/website?requireActive=false" target="_blank"><img width="30" src="https://opencollective.com/tickerq/backer/0/avatar.svg?requireActive=false"></a>
----
-
-## 🤝 Contribution
-
-PRs, ideas, and issues are welcome!
-
-1. Fork & branch
-2. Code your change
-3. Submit a Pull Request
-
----
-
-## 📄 License
-
-**MIT OR Apache 2.0** © [Arcenox](https://arcenox.com)  
-You may choose either license to use this software.
+Dual licensed under **MIT** and **Apache 2.0** © [Arcenox LLC](https://arcenox.com)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,8 @@
         <RepositoryUrl>https://github.com/arcenox-co/TickerQ</RepositoryUrl>
         <PackageProjectUrl>https://tickerq.net/</PackageProjectUrl>
         <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
+        <Authors>Arcenox LLC</Authors>
+        <Copyright>Copyright 2025-present Arcenox LLC</Copyright>
         <PackageTags>ticker;queue;cron;time;scheduler;fire-and-forget</PackageTags>
         <PackageIcon>icon.jpg</PackageIcon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
## Automated Branch Sync

This PR syncs recent changes from `main` to `net9`.

### What was done:
- Cherry-picked new commits from main
- Updated `Directory.Build.props` versions (10.x.x → ${dotnet_version}.x.x, DotNetVersion range)
- Preserved all `.csproj` files from net9
- Preserved version-specific files listed in `.sync-exclude`
- Skipped commits already in the target branch (patch-level dedup)

### Version-specific files (NOT synced):
Files in `.sync-exclude` have different implementations per .NET version and are kept as-is.

---
_Created automatically by branch sync workflow_