### PR TITLE
Fix Build() race condition and add startup validation

### DIFF
--- a/src/TickerQ.Utilities/TickerFunctionProvider.cs
+++ b/src/TickerQ.Utilities/TickerFunctionProvider.cs
@@ -20,15 +20,19 @@ namespace TickerQ.Utilities
     /// </summary>
     public static class TickerFunctionProvider
     {
+        private static readonly object _buildLock = new();
+
         // Callback actions to collect registrations
         private static Action<Dictionary<string, (string, Type)>> _requestTypeRegistrations;
         private static Action<Dictionary<string, (string RequestType, string RequestExampleJson)>> _requestInfoRegistrations;
         private static Action<Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>> _functionRegistrations;
-        
+
         // Final frozen dictionaries
-        public static FrozenDictionary<string, (string, Type)> TickerFunctionRequestTypes;
-        public static FrozenDictionary<string, (string RequestType, string RequestExampleJson)> TickerFunctionRequestInfos;
-        public static FrozenDictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)> TickerFunctions;
+        public static FrozenDictionary<string, (string, Type)> TickerFunctionRequestTypes = FrozenDictionary<string, (string, Type)>.Empty;
+        public static FrozenDictionary<string, (string RequestType, string RequestExampleJson)> TickerFunctionRequestInfos = FrozenDictionary<string, (string RequestType, string RequestExampleJson)>.Empty;
+        public static FrozenDictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)> TickerFunctions = FrozenDictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>.Empty;
+
+        public static bool IsBuilt { get; private set; }
 
         /// <summary>
         /// Registers ticker functions during application startup by adding to the callback chain.
@@ -158,57 +162,36 @@ namespace TickerQ.Utilities
         /// </summary>
         public static void Build()
         {
-            // Build functions dictionary
-            if (_functionRegistrations != null)
+            lock (_buildLock)
             {
-                // Single pass: execute callbacks directly on final dictionary
-                var functionsDict = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>();
-                _functionRegistrations(functionsDict);
-                TickerFunctions = functionsDict.ToFrozenDictionary();
-                _functionRegistrations = null; // Release callback chain
-            }
-            else
-            {
-                if (TickerFunctions == null)
+                // Build functions dictionary
+                if (_functionRegistrations != null)
                 {
-                    TickerFunctions = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>()
-                        .ToFrozenDictionary();
+                    var functionsDict = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>();
+                    _functionRegistrations(functionsDict);
+                    TickerFunctions = functionsDict.ToFrozenDictionary();
+                    _functionRegistrations = null;
                 }
-            }
 
-            // Build request types dictionary  
-            if (_requestTypeRegistrations != null)
-            {
-                // Single pass: execute callbacks directly on final dictionary
-                var requestTypesDict = new Dictionary<string, (string, Type)>();
-                _requestTypeRegistrations(requestTypesDict);
-                TickerFunctionRequestTypes = requestTypesDict.ToFrozenDictionary();
-                _requestTypeRegistrations = null; // Release callback chain
-            }
-            else
-            {
-                if (TickerFunctionRequestTypes == null)
+                // Build request types dictionary
+                if (_requestTypeRegistrations != null)
                 {
-                    TickerFunctionRequestTypes = new Dictionary<string, (string, Type)>()
-                        .ToFrozenDictionary();
+                    var requestTypesDict = new Dictionary<string, (string, Type)>();
+                    _requestTypeRegistrations(requestTypesDict);
+                    TickerFunctionRequestTypes = requestTypesDict.ToFrozenDictionary();
+                    _requestTypeRegistrations = null;
                 }
-            }
 
-            // Build request info dictionary (string type + example JSON)
-            if (_requestInfoRegistrations != null)
-            {
-                var requestInfoDict = new Dictionary<string, (string RequestType, string RequestExampleJson)>();
-                _requestInfoRegistrations(requestInfoDict);
-                TickerFunctionRequestInfos = requestInfoDict.ToFrozenDictionary();
-                _requestInfoRegistrations = null;
-            }
-            else
-            {
-                if (TickerFunctionRequestInfos == null)
+                // Build request info dictionary (string type + example JSON)
+                if (_requestInfoRegistrations != null)
                 {
-                    TickerFunctionRequestInfos = new Dictionary<string, (string RequestType, string RequestExampleJson)>()
-                        .ToFrozenDictionary();
+                    var requestInfoDict = new Dictionary<string, (string RequestType, string RequestExampleJson)>();
+                    _requestInfoRegistrations(requestInfoDict);
+                    TickerFunctionRequestInfos = requestInfoDict.ToFrozenDictionary();
+                    _requestInfoRegistrations = null;
                 }
+
+                IsBuilt = true;
             }
         }
     }

--- a/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
+++ b/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
@@ -96,6 +96,10 @@ namespace TickerQ.DependencyInjection
             services.AddSingleton(_ => optionInstance);
             services.AddSingleton(_ => tickerExecutionContext);
             services.AddSingleton(_ => schedulerOptionsBuilder);
+
+            // Register AFTER initializer and scheduler to ensure it runs last
+            services.AddHostedService<TickerQStartupValidator>();
+
             return services;
         }
 

--- a/src/TickerQ/Src/BackgroundServices/TickerQStartupValidator.cs
+++ b/src/TickerQ/Src/BackgroundServices/TickerQStartupValidator.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Enums;
+
+namespace TickerQ.BackgroundServices;
+
+internal class TickerQStartupValidator : IHostedService
+{
+    private readonly TickerExecutionContext _executionContext;
+    private readonly TickerQInitializerHostedService _initializer;
+    private readonly ILogger<TickerQStartupValidator> _logger;
+
+    public TickerQStartupValidator(
+        TickerExecutionContext executionContext,
+        TickerQInitializerHostedService initializer,
+        ILogger<TickerQStartupValidator> logger)
+    {
+        _executionContext = executionContext;
+        _initializer = initializer;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_initializer.InitializationRequested)
+        {
+            const string message = "TickerQ — UseTickerQ() was not called. Call app.UseTickerQ() before app.Run() to initialize the scheduler.";
+            _logger.LogWarning(message);
+            _executionContext.NotifyCoreAction?.Invoke(message, CoreNotifyActionType.NotifyHostExceptionMessage);
+        }
+        else if (TickerFunctionProvider.TickerFunctions.Count == 0)
+        {
+            const string message = "TickerQ — No ticker functions registered. Ensure you have methods decorated with [TickerFunction].";
+            _logger.LogWarning(message);
+            _executionContext.NotifyCoreAction?.Invoke(message, CoreNotifyActionType.NotifyHostExceptionMessage);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
+++ b/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
@@ -37,12 +37,16 @@ public class TickerFunctionProviderTests : IDisposable
         var type = typeof(TickerFunctionProvider);
         const BindingFlags flags = BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public;
 
-        type.GetField("TickerFunctions", flags)!.SetValue(null, null);
-        type.GetField("TickerFunctionRequestTypes", flags)!.SetValue(null, null);
-        type.GetField("TickerFunctionRequestInfos", flags)!.SetValue(null, null);
+        type.GetField("TickerFunctions", flags)!.SetValue(null,
+            System.Collections.Frozen.FrozenDictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>.Empty);
+        type.GetField("TickerFunctionRequestTypes", flags)!.SetValue(null,
+            System.Collections.Frozen.FrozenDictionary<string, (string, Type)>.Empty);
+        type.GetField("TickerFunctionRequestInfos", flags)!.SetValue(null,
+            System.Collections.Frozen.FrozenDictionary<string, (string, string)>.Empty);
         type.GetField("_functionRegistrations", flags)!.SetValue(null, null);
         type.GetField("_requestTypeRegistrations", flags)!.SetValue(null, null);
         type.GetField("_requestInfoRegistrations", flags)!.SetValue(null, null);
+        type.GetProperty("IsBuilt", flags)!.SetValue(null, false);
     }
 
     private static Task NoOpDelegate(CancellationToken ct, IServiceProvider sp, TickerQ.Utilities.Base.TickerFunctionContext ctx)


### PR DESCRIPTION
## Summary

- **Fix #705** — `TickerFunctionProvider.Build()` is now thread-safe with a `lock`, preventing concurrent hosts (e.g. multiple `WebApplicationFactory` instances in tests) from overwriting a populated `FrozenDictionary` with an empty one
- **Prevent NullReferenceException** — Static `FrozenDictionary` fields initialized to `.Empty` instead of `null`, so dashboard API calls don't crash when `UseTickerQ()` is not called
- **Startup validation** — New `TickerQStartupValidator` `IHostedService` warns at startup:
  - `"UseTickerQ() was not called"` — when `Build()` never ran
  - `"No ticker functions registered"` — when `UseTickerQ()` was called but no `[TickerFunction]` methods exist

## Changes

| File | Change |
|------|--------|
| `TickerFunctionProvider.cs` | `lock` on `Build()`, `IsBuilt` flag, `FrozenDictionary.Empty` init |
| `TickerQStartupValidator.cs` | New lightweight `IHostedService` for startup warnings |
| `TickerQServiceExtensions.cs` | Register validator in `AddTickerQ()` |
| `TickerFunctionProviderTests.cs` | Update `ResetProvider()` for new field defaults |

## Test plan

- [x] All 487 existing tests pass
- [x] Validated warning fires when `UseTickerQ()` is omitted (test project with PostgreSQL + Dashboard)
- [x] AOT-friendly — no reflection in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)