### PR TITLE
Fix TickerFunctionProvider.Build() empty TickerFunctions with concurrent test hosts 

### DIFF
--- a/src/TickerQ.Utilities/TickerFunctionProvider.cs
+++ b/src/TickerQ.Utilities/TickerFunctionProvider.cs
@@ -48,13 +48,16 @@ namespace TickerQ.Utilities
             if (functions.Count == 0)
                 return;
 
-            _functionRegistrations += dict =>
+            lock (_buildLock)
             {
-                foreach (var (key, value) in functions)
+                _functionRegistrations += dict =>
                 {
-                    dict.TryAdd(key, value); // Preserves existing entries
-                }
-            };
+                    foreach (var (key, value) in functions)
+                    {
+                        dict.TryAdd(key, value); // Preserves existing entries
+                    }
+                };
+            }
         }
 
         /// <summary>
@@ -84,13 +87,16 @@ namespace TickerQ.Utilities
             if (requestTypes.Count == 0)
                 return;
 
-            _requestTypeRegistrations += dict =>
+            lock (_buildLock)
             {
-                foreach (var (key, value) in requestTypes)
+                _requestTypeRegistrations += dict =>
                 {
-                    dict.TryAdd(key, value); // Preserves existing entries
-                }
-            };
+                    foreach (var (key, value) in requestTypes)
+                    {
+                        dict.TryAdd(key, value); // Preserves existing entries
+                    }
+                };
+            }
         }
 
         /// <summary>
@@ -119,13 +125,16 @@ namespace TickerQ.Utilities
             if (requestInfos.Count == 0)
                 return;
 
-            _requestInfoRegistrations += dict =>
+            lock (_buildLock)
             {
-                foreach (var (key, value) in requestInfos)
+                _requestInfoRegistrations += dict =>
                 {
-                    dict.TryAdd(key, value);
-                }
-            };
+                    foreach (var (key, value) in requestInfos)
+                    {
+                        dict.TryAdd(key, value);
+                    }
+                };
+            }
         }
 
         /// <summary>
@@ -136,22 +145,26 @@ namespace TickerQ.Utilities
         /// <exception cref="ArgumentNullException">Thrown when cronUpdates parameter is null.</exception>
         internal static void UpdateCronExpressionsFromIConfiguration(IConfiguration configuration)
         {
-            _functionRegistrations += dict =>
+            lock (_buildLock)
             {
-                foreach (var (key, value) in dict)
+                _functionRegistrations += dict =>
                 {
-                    if (value.cronExpression.StartsWith('%'))
+                    foreach (var (key, value) in dict)
                     {
-                        var configKey = value.cronExpression.Trim('%');
-                        var mappedCronExpression = configuration[configKey];
-            
-                        if (!string.IsNullOrEmpty(mappedCronExpression))
+                        if (value.cronExpression.StartsWith('%'))
                         {
-                            dict[key] = (mappedCronExpression, value.Priority, value.Delegate, value.MaxConcurrency);
+                            var configKey = value.cronExpression.Trim('%');
+                            var mappedCronExpression = configuration[configKey];
+
+                            if (!string.IsNullOrEmpty(mappedCronExpression))
+                            {
+                                dict[key] = (mappedCronExpression, value.Priority, value.Delegate,
+                                             value.MaxConcurrency);
+                            }
                         }
                     }
-                }
-            };
+                };
+            }
         }
 
         /// <summary>

--- a/src/TickerQ.Utilities/TickerFunctionProvider.cs
+++ b/src/TickerQ.Utilities/TickerFunctionProvider.cs
@@ -167,7 +167,7 @@ namespace TickerQ.Utilities
                 // Build functions dictionary
                 if (_functionRegistrations != null)
                 {
-                    var functionsDict = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>();
+                    var functionsDict = new Dictionary<string, (string cronExpression, TickerTaskPriority Priority, TickerFunctionDelegate Delegate, int MaxConcurrency)>(TickerFunctions);
                     _functionRegistrations(functionsDict);
                     TickerFunctions = functionsDict.ToFrozenDictionary();
                     _functionRegistrations = null;
@@ -176,7 +176,7 @@ namespace TickerQ.Utilities
                 // Build request types dictionary
                 if (_requestTypeRegistrations != null)
                 {
-                    var requestTypesDict = new Dictionary<string, (string, Type)>();
+                    var requestTypesDict = new Dictionary<string, (string, Type)>(TickerFunctionRequestTypes);
                     _requestTypeRegistrations(requestTypesDict);
                     TickerFunctionRequestTypes = requestTypesDict.ToFrozenDictionary();
                     _requestTypeRegistrations = null;
@@ -185,7 +185,7 @@ namespace TickerQ.Utilities
                 // Build request info dictionary (string type + example JSON)
                 if (_requestInfoRegistrations != null)
                 {
-                    var requestInfoDict = new Dictionary<string, (string RequestType, string RequestExampleJson)>();
+                    var requestInfoDict = new Dictionary<string, (string RequestType, string RequestExampleJson)>(TickerFunctionRequestInfos);
                     _requestInfoRegistrations(requestInfoDict);
                     TickerFunctionRequestInfos = requestInfoDict.ToFrozenDictionary();
                     _requestInfoRegistrations = null;

--- a/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
+++ b/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
@@ -183,6 +183,30 @@ public class TickerFunctionProviderTests : IDisposable
         Assert.True(TickerFunctionProvider.TickerFunctions.ContainsKey("DoubleFunc"));
         Assert.Single(TickerFunctionProvider.TickerFunctions);
     }
+    
+    [Fact]
+    public void Build_CalledTwiceWithCronUpdateAfterInitialBuild_DoesNotClearFunctions()
+    {
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
+        {
+            ["CronRaceFunc"] = ("%CronSettings:Schedule%", TickerTaskPriority.Normal, NoOpDelegate, 0)
+        };
+
+        TickerFunctionProvider.RegisterFunctions(functions);
+        TickerFunctionProvider.Build();
+
+        // Simulate another host that only contributes config-based cron update callback.
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["CronSettings:Schedule"].Returns("0 30 * * *");
+
+        TickerFunctionProvider.UpdateCronExpressionsFromIConfiguration(configuration);
+       
+        // Second Build should not throw and data should still be present
+        TickerFunctionProvider.Build();
+
+        Assert.True(TickerFunctionProvider.TickerFunctions.ContainsKey("CronRaceFunc"));
+        Assert.Equal("0 30 * * *", TickerFunctionProvider.TickerFunctions["CronRaceFunc"].cronExpression);
+    }
 
     // ---------------------------------------------------------------
     // 7. UpdateCronExpressionsFromIConfiguration – mock IConfiguration

--- a/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
+++ b/tests/TickerQ.Tests/TickerFunctionProviderTests.cs
@@ -189,23 +189,22 @@ public class TickerFunctionProviderTests : IDisposable
     {
         var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
         {
-            ["CronRaceFunc"] = ("%CronSettings:Schedule%", TickerTaskPriority.Normal, NoOpDelegate, 0)
+            ["CronRaceFunc"] = ("0 0 1 * *", TickerTaskPriority.Normal, NoOpDelegate, 0)
         };
 
+        var configuration = Substitute.For<IConfiguration>();
+     
         TickerFunctionProvider.RegisterFunctions(functions);
+        
+        TickerFunctionProvider.UpdateCronExpressionsFromIConfiguration(configuration);
         TickerFunctionProvider.Build();
 
-        // Simulate another host that only contributes config-based cron update callback.
-        var configuration = Substitute.For<IConfiguration>();
-        configuration["CronSettings:Schedule"].Returns("0 30 * * *");
-
+        // Simulate another host that UpdateCronExpressionsFromIConfiguration and Build again.
         TickerFunctionProvider.UpdateCronExpressionsFromIConfiguration(configuration);
-       
-        // Second Build should not throw and data should still be present
         TickerFunctionProvider.Build();
 
         Assert.True(TickerFunctionProvider.TickerFunctions.ContainsKey("CronRaceFunc"));
-        Assert.Equal("0 30 * * *", TickerFunctionProvider.TickerFunctions["CronRaceFunc"].cronExpression);
+        Assert.Single(TickerFunctionProvider.TickerFunctions);
     }
 
     // ---------------------------------------------------------------
@@ -228,6 +227,30 @@ public class TickerFunctionProviderTests : IDisposable
         TickerFunctionProvider.Build();
 
         Assert.Equal("0 30 * * *", TickerFunctionProvider.TickerFunctions["CronFunc"].cronExpression);
+    }
+    
+    [Fact]
+    public void UpdateCronExpressionsFromIConfiguration_AfterInitialBuild_UpdatesExpressions()
+    {
+        var functions = new Dictionary<string, (string, TickerTaskPriority, TickerFunctionDelegate, int)>
+        {
+            ["CronRaceFunc"] = ("%CronSettings:Schedule%", TickerTaskPriority.Normal, NoOpDelegate, 0)
+        };
+
+        TickerFunctionProvider.RegisterFunctions(functions);
+        TickerFunctionProvider.Build();
+
+        // Simulate another host that contributes config-based cron update callback.
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["CronSettings:Schedule"].Returns("0 30 * * *");
+
+        TickerFunctionProvider.UpdateCronExpressionsFromIConfiguration(configuration);
+       
+        // Second Build should not throw and data should still be present
+        TickerFunctionProvider.Build();
+
+        Assert.True(TickerFunctionProvider.TickerFunctions.ContainsKey("CronRaceFunc"));
+        Assert.Equal("0 30 * * *", TickerFunctionProvider.TickerFunctions["CronRaceFunc"].cronExpression);
     }
 
     [Fact]


### PR DESCRIPTION
Fix #705 

This pull request improves the robustness of the `TickerFunctionProvider` by ensuring that repeated calls to `Build()` and updates to cron expressions do not clear or lose existing function registrations or configuration-based updates. It also adds new unit tests to verify this behavior.

**Improvements to dictionary initialization in `Build()`:**

* The dictionaries for `TickerFunctions`, `TickerFunctionRequestTypes`, and `TickerFunctionRequestInfos` are now initialized with their existing values instead of starting empty, ensuring that repeated builds retain previously registered data. [[1]](diffhunk://#diff-f2b64690cf21c0b49d126fd803e368d1162798b233cf76e1248b37a168561e54L170-R170) [[2]](diffhunk://#diff-f2b64690cf21c0b49d126fd803e368d1162798b233cf76e1248b37a168561e54L179-R179) [[3]](diffhunk://#diff-f2b64690cf21c0b49d126fd803e368d1162798b233cf76e1248b37a168561e54L188-R188)

**Enhancements to test coverage:**

* Added `Build_CalledTwiceWithCronUpdateAfterInitialBuild_DoesNotClearFunctions` test to verify that calling `Build()` multiple times after updating cron expressions does not remove existing functions.
* Added `UpdateCronExpressionsFromIConfiguration_AfterInitialBuild_UpdatesExpressions` test to ensure that configuration-based cron updates persist correctly across multiple builds.


