### PR TITLE
Fix startup cron occurrence duplicate scheduling (#776)

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -599,10 +599,13 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
             .ConfigureAwait(false);
     }
     
-    public async Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default)
+    public async Task<int> SkipStaleCronOccurrencesAsync(TimeSpan staleThreshold, CancellationToken cancellationToken = default)
     {
+        if (staleThreshold <= TimeSpan.Zero)
+            return 0;
+
         var now = _clock.UtcNow;
-        var cutoff = now.AddSeconds(-5);
+        var cutoff = now - staleThreshold;
 
         using var session = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         var dbContext = session.Context;

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -599,5 +599,23 @@ internal abstract class BasePersistenceProvider<TDbContext, TTimeTicker, TCronTi
             .ConfigureAwait(false);
     }
     
+    public async Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default)
+    {
+        var now = _clock.UtcNow;
+        var cutoff = now.AddSeconds(-5);
+
+        using var session = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var dbContext = session.Context;
+
+        return await dbContext.Set<CronTickerOccurrenceEntity<TCronTicker>>()
+            .Where(x => x.Status == TickerStatus.Idle || x.Status == TickerStatus.Queued)
+            .Where(x => x.ExecutionTime < cutoff)
+            .ExecuteUpdateAsync(setter => setter
+                .SetProperty(x => x.Status, TickerStatus.Skipped)
+                .SetProperty(x => x.SkippedReason, "Missed: occurrence was pending when the application restarted")
+                .SetProperty(x => x.UpdatedAt, now), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     #endregion
 }

--- a/src/TickerQ.Utilities/Interfaces/ITickerPersistenceProvider.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerPersistenceProvider.cs
@@ -38,7 +38,7 @@ namespace TickerQ.Utilities.Interfaces
         Task<byte[]> GetCronTickerOccurrenceRequest(Guid tickerId, CancellationToken cancellationToken = default);
         Task UpdateCronTickerOccurrencesWithUnifiedContext(Guid[] timeTickerIds, InternalFunctionContext functionContext, CancellationToken cancellationToken = default);
         Task ReleaseDeadNodeOccurrenceResources(string instanceIdentifier, CancellationToken cancellationToken = default);
-        Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
+        Task<int> SkipStaleCronOccurrencesAsync(TimeSpan staleThreshold, CancellationToken cancellationToken = default) => Task.FromResult(0);
         #endregion
         
         #region Time_Ticker_Shared_Methods

--- a/src/TickerQ.Utilities/Interfaces/ITickerPersistenceProvider.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerPersistenceProvider.cs
@@ -38,6 +38,7 @@ namespace TickerQ.Utilities.Interfaces
         Task<byte[]> GetCronTickerOccurrenceRequest(Guid tickerId, CancellationToken cancellationToken = default);
         Task UpdateCronTickerOccurrencesWithUnifiedContext(Guid[] timeTickerIds, InternalFunctionContext functionContext, CancellationToken cancellationToken = default);
         Task ReleaseDeadNodeOccurrenceResources(string instanceIdentifier, CancellationToken cancellationToken = default);
+        Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         #endregion
         
         #region Time_Ticker_Shared_Methods

--- a/src/TickerQ.Utilities/Interfaces/Managers/IInternalTickerManager.cs
+++ b/src/TickerQ.Utilities/Interfaces/Managers/IInternalTickerManager.cs
@@ -18,6 +18,6 @@ namespace TickerQ.Utilities.Interfaces.Managers
         Task DeleteTicker(Guid tickerId, TickerType type, CancellationToken cancellationToken = default);
         Task ReleaseDeadNodeResources(string instanceIdentifier, CancellationToken cancellationToken = default);
         Task UpdateSkipTimeTickersWithUnifiedContextAsync(InternalFunctionContext[] context, CancellationToken cancellationToken = default);
-        Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default);
+        Task<int> SkipStaleCronOccurrencesAsync(TimeSpan staleThreshold, CancellationToken cancellationToken = default);
     }
 }

--- a/src/TickerQ.Utilities/Interfaces/Managers/IInternalTickerManager.cs
+++ b/src/TickerQ.Utilities/Interfaces/Managers/IInternalTickerManager.cs
@@ -18,5 +18,6 @@ namespace TickerQ.Utilities.Interfaces.Managers
         Task DeleteTicker(Guid tickerId, TickerType type, CancellationToken cancellationToken = default);
         Task ReleaseDeadNodeResources(string instanceIdentifier, CancellationToken cancellationToken = default);
         Task UpdateSkipTimeTickersWithUnifiedContextAsync(InternalFunctionContext[] context, CancellationToken cancellationToken = default);
+        Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
+++ b/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
@@ -467,6 +467,9 @@ namespace TickerQ.Utilities.Managers
                 await _persistenceProvider.RemoveTimeTickers([tickerId], cancellationToken).ConfigureAwait(false);
         }
 
+        public async Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default)
+            => await _persistenceProvider.SkipStaleCronOccurrencesAsync(cancellationToken).ConfigureAwait(false);
+
         public async Task ReleaseDeadNodeResources(string instanceIdentifier, CancellationToken cancellationToken = default)
         {
             var cronOccurrence = _persistenceProvider.ReleaseDeadNodeOccurrenceResources(instanceIdentifier, cancellationToken);

--- a/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
+++ b/src/TickerQ.Utilities/Managers/InternalTickerManager.cs
@@ -467,8 +467,8 @@ namespace TickerQ.Utilities.Managers
                 await _persistenceProvider.RemoveTimeTickers([tickerId], cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default)
-            => await _persistenceProvider.SkipStaleCronOccurrencesAsync(cancellationToken).ConfigureAwait(false);
+        public async Task<int> SkipStaleCronOccurrencesAsync(TimeSpan staleThreshold, CancellationToken cancellationToken = default)
+            => await _persistenceProvider.SkipStaleCronOccurrencesAsync(staleThreshold, cancellationToken).ConfigureAwait(false);
 
         public async Task ReleaseDeadNodeResources(string instanceIdentifier, CancellationToken cancellationToken = default)
         {

--- a/src/TickerQ.Utilities/TickerOptionsBuilder.cs
+++ b/src/TickerQ.Utilities/TickerOptionsBuilder.cs
@@ -107,6 +107,22 @@ namespace TickerQ.Utilities
         }
 
         /// <summary>
+        /// Enables skipping of stale cron occurrences on application startup.
+        /// Idle/Queued occurrences whose execution time is further behind the current
+        /// time than <paramref name="threshold"/> are marked <c>Skipped</c>, preventing
+        /// duplicate executions after a restart (see #776).
+        /// </summary>
+        /// <param name="threshold">
+        /// How far behind the current time an occurrence must be to be considered stale.
+        /// Defaults to 5 seconds when not specified.
+        /// </param>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> SkipStaleCronOccurrencesOnStartup(TimeSpan? threshold = null)
+        {
+            _schedulerOptions.StaleCronOccurrenceThreshold = threshold ?? TimeSpan.FromSeconds(5);
+            return this;
+        }
+
+        /// <summary>
         /// Disable automatic seeding of code-defined cron tickers on startup.
         /// </summary>
         public TickerOptionsBuilder<TTimeTicker, TCronTicker> IgnoreSeedDefinedCronTickers()
@@ -196,6 +212,17 @@ namespace TickerQ.Utilities
         /// Prevents tight loops when tasks are due or when the database is empty.
         /// </summary>
         public TimeSpan MinPollingInterval { get; set; } = TimeSpan.FromSeconds(1);
+        /// <summary>
+        /// How far behind the current time an Idle/Queued cron occurrence must be
+        /// before it is marked <c>Skipped</c> on startup. Occurrences whose
+        /// <c>ExecutionTime</c> is closer to the current time than this threshold
+        /// are left for normal scheduling to pick up.
+        /// <para>
+        /// Disabled by default (<see cref="TimeSpan.Zero"/>). Enable via
+        /// <c>SkipStaleCronOccurrencesOnStartup()</c> on the options builder.
+        /// </para>
+        /// </summary>
+        public TimeSpan StaleCronOccurrenceThreshold { get; set; } = TimeSpan.Zero;
         public TimeZoneInfo SchedulerTimeZone = TimeZoneInfo.Local;
     }
 }

--- a/src/TickerQ/Src/BackgroundServices/TickerQInitializerHostedService.cs
+++ b/src/TickerQ/Src/BackgroundServices/TickerQInitializerHostedService.cs
@@ -97,7 +97,11 @@ internal sealed class TickerQInitializerHostedService : IHostedService
 
     private static async Task SkipStaleCronOccurrencesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
+        var schedulerOptions = serviceProvider.GetRequiredService<SchedulerOptionsBuilder>();
+        if (schedulerOptions.StaleCronOccurrenceThreshold <= TimeSpan.Zero)
+            return;
+
         var internalTickerManager = serviceProvider.GetRequiredService<IInternalTickerManager>();
-        await internalTickerManager.SkipStaleCronOccurrencesAsync(cancellationToken);
+        await internalTickerManager.SkipStaleCronOccurrencesAsync(schedulerOptions.StaleCronOccurrenceThreshold, cancellationToken);
     }
 }

--- a/src/TickerQ/Src/BackgroundServices/TickerQInitializerHostedService.cs
+++ b/src/TickerQ/Src/BackgroundServices/TickerQInitializerHostedService.cs
@@ -69,6 +69,12 @@ internal sealed class TickerQInitializerHostedService : IHostedService
             await options.CronSeederAction(_serviceProvider);
         }
 
+        // Skip stale cron occurrences that were pending before this restart.
+        // This prevents the fallback service from catching up past-due occurrences
+        // from a previous application lifecycle, which would cause unexpected
+        // duplicate executions at startup (see #776).
+        await SkipStaleCronOccurrencesAsync(_serviceProvider, cancellationToken);
+
         if (_executionContext.ExternalProviderApplicationAction != null)
         {
             _executionContext.ExternalProviderApplicationAction(_serviceProvider);
@@ -87,5 +93,11 @@ internal sealed class TickerQInitializerHostedService : IHostedService
             .Select(x => (x.Key, x.Value.cronExpression)).ToArray();
 
         await internalTickerManager.MigrateDefinedCronTickers(functionsToSeed);
+    }
+
+    private static async Task SkipStaleCronOccurrencesAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var internalTickerManager = serviceProvider.GetRequiredService<IInternalTickerManager>();
+        await internalTickerManager.SkipStaleCronOccurrencesAsync(cancellationToken);
     }
 }

--- a/src/TickerQ/Src/Provider/TickerInMemoryPersistenceProvider.cs
+++ b/src/TickerQ/Src/Provider/TickerInMemoryPersistenceProvider.cs
@@ -1007,6 +1007,36 @@ namespace TickerQ.Provider
             return Task.FromResult(acquired.ToArray());
         }
 
+        public Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var cutoff = now.AddSeconds(-5);
+            var count = 0;
+
+            var staleOccurrences = CronOccurrences.Values
+                .Where(x => x.Status == TickerStatus.Idle || x.Status == TickerStatus.Queued)
+                .Where(x => x.ExecutionTime < cutoff)
+                .ToArray();
+
+            foreach (var occurrence in staleOccurrences)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!CronOccurrences.TryGetValue(occurrence.Id, out var current))
+                    continue;
+
+                var updated = CloneCronOccurrence(current);
+                updated.Status = TickerStatus.Skipped;
+                updated.SkippedReason = "Missed: occurrence was pending when the application restarted";
+                updated.UpdatedAt = now;
+
+                if (CronOccurrences.TryUpdate(occurrence.Id, updated, current))
+                    count++;
+            }
+
+            return Task.FromResult(count);
+        }
+
         #endregion
 
         #region Helper Methods

--- a/src/TickerQ/Src/Provider/TickerInMemoryPersistenceProvider.cs
+++ b/src/TickerQ/Src/Provider/TickerInMemoryPersistenceProvider.cs
@@ -1007,10 +1007,13 @@ namespace TickerQ.Provider
             return Task.FromResult(acquired.ToArray());
         }
 
-        public Task<int> SkipStaleCronOccurrencesAsync(CancellationToken cancellationToken = default)
+        public Task<int> SkipStaleCronOccurrencesAsync(TimeSpan staleThreshold, CancellationToken cancellationToken = default)
         {
+            if (staleThreshold <= TimeSpan.Zero)
+                return Task.FromResult(0);
+
             var now = _clock.UtcNow;
-            var cutoff = now.AddSeconds(-5);
+            var cutoff = now - staleThreshold;
             var count = 0;
 
             var staleOccurrences = CronOccurrences.Values

--- a/tests/TickerQ.Tests/DesignTimeToolDetectionTests.cs
+++ b/tests/TickerQ.Tests/DesignTimeToolDetectionTests.cs
@@ -70,6 +70,7 @@ public class DesignTimeToolDetectionTests
         services.AddSingleton(context);
         services.AddSingleton(configuration);
         services.AddSingleton(internalManager);
+        services.AddSingleton(new SchedulerOptionsBuilder());
 
         var sp = services.BuildServiceProvider();
         var initializer = new TickerQInitializerHostedService(context, sp, configuration);
@@ -123,6 +124,7 @@ public class DesignTimeToolDetectionTests
         services.AddSingleton(context);
         services.AddSingleton(configuration);
         services.AddSingleton(internalManager);
+        services.AddSingleton(new SchedulerOptionsBuilder());
 
         var sp = services.BuildServiceProvider();
         var initializer = new TickerQInitializerHostedService(context, sp, configuration);

--- a/tests/TickerQ.Tests/SkipStaleCronOccurrencesTests.cs
+++ b/tests/TickerQ.Tests/SkipStaleCronOccurrencesTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using TickerQ.Provider;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Interfaces;
+using TickerQ.Utilities.Models;
+using Xunit;
+
+namespace TickerQ.Tests;
+
+public class SkipStaleCronOccurrencesTests : IAsyncLifetime
+{
+    private sealed class FakeTimeTicker : TimeTickerEntity<FakeTimeTicker> { }
+    private sealed class FakeCronTicker : CronTickerEntity { }
+
+    private readonly ITickerClock _clock;
+    private readonly TickerInMemoryPersistenceProvider<FakeTimeTicker, FakeCronTicker> _provider;
+    private readonly DateTime _now;
+    private readonly List<Guid> _createdCronTickerIds = new();
+    private readonly List<Guid> _createdOccurrenceIds = new();
+
+    public SkipStaleCronOccurrencesTests()
+    {
+        _now = new DateTime(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        _clock = Substitute.For<ITickerClock>();
+        _clock.UtcNow.Returns(_now);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_clock);
+        services.AddSingleton(new SchedulerOptionsBuilder { NodeIdentifier = "test-node" });
+        var serviceProvider = services.BuildServiceProvider();
+
+        _provider = new TickerInMemoryPersistenceProvider<FakeTimeTicker, FakeCronTicker>(serviceProvider);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_createdOccurrenceIds.Count > 0)
+            await _provider.RemoveCronTickerOccurrences(_createdOccurrenceIds.ToArray(), CancellationToken.None);
+        if (_createdCronTickerIds.Count > 0)
+            await _provider.RemoveCronTickers(_createdCronTickerIds.ToArray(), CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_SkipsPastDueIdleOccurrences()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create an occurrence that is 10 seconds past-due (well beyond the 5s grace)
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(1, skipped);
+
+        // Verify it's now Skipped
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Single(all);
+        Assert.Equal(TickerStatus.Skipped, all[0].Status);
+        Assert.Equal("Missed: occurrence was pending when the application restarted", all[0].SkippedReason);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_SkipsPastDueQueuedOccurrences()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create a Queued occurrence that is 10 seconds past-due
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Queued);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(1, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Single(all);
+        Assert.Equal(TickerStatus.Skipped, all[0].Status);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_DoesNotSkipFutureOccurrences()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create a future occurrence (30 seconds from now)
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(30), TickerStatus.Idle);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(0, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Single(all);
+        Assert.Equal(TickerStatus.Idle, all[0].Status);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_DoesNotSkipRecentPastDueWithinGracePeriod()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create an occurrence that is only 2 seconds past-due (within 5s grace period)
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-2), TickerStatus.Idle);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(0, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Single(all);
+        Assert.Equal(TickerStatus.Idle, all[0].Status);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_DoesNotAffectCompletedOccurrences()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create a completed past-due occurrence
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-60), TickerStatus.Done);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(0, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Single(all);
+        Assert.Equal(TickerStatus.Done, all[0].Status);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_DoesNotAffectInProgressOccurrences()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create an InProgress past-due occurrence (being actively processed by another node)
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-60), TickerStatus.InProgress);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(0, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Single(all);
+        Assert.Equal(TickerStatus.InProgress, all[0].Status);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_IsIdempotent()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
+
+        var first = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var second = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        Assert.Equal(1, first);
+        Assert.Equal(0, second); // Already Skipped, should not match again
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_SkippedOccurrencesNotPickedUpByFallback()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Create a past-due Idle occurrence
+        await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
+
+        // Skip stale occurrences
+        await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+
+        // Fallback should find no timed-out occurrences
+        var fallbackResults = await CollectAsync(
+            _provider.QueueTimedOutCronTickerOccurrences(CancellationToken.None));
+
+        Assert.Empty(fallbackResults);
+    }
+
+    private async Task SetupCronTicker(Guid cronTickerId)
+    {
+        var cronTicker = new FakeCronTicker
+        {
+            Id = cronTickerId,
+            Function = "TestFunc",
+            Expression = "* * * * *"
+        };
+        await _provider.InsertCronTickers(new[] { cronTicker }, CancellationToken.None);
+        _createdCronTickerIds.Add(cronTickerId);
+    }
+
+    private async Task<Guid> InsertOccurrence(Guid cronTickerId, DateTime executionTime, TickerStatus status)
+    {
+        var id = Guid.NewGuid();
+        var occurrence = new CronTickerOccurrenceEntity<FakeCronTicker>
+        {
+            Id = id,
+            CronTickerId = cronTickerId,
+            ExecutionTime = executionTime,
+            Status = status,
+            CreatedAt = _now.AddMinutes(-5),
+            UpdatedAt = _now.AddMinutes(-5)
+        };
+        await _provider.InsertCronTickerOccurrences(new[] { occurrence }, CancellationToken.None);
+        _createdOccurrenceIds.Add(id);
+        return id;
+    }
+
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var list = new List<T>();
+        await foreach (var item in source)
+            list.Add(item);
+        return list;
+    }
+}

--- a/tests/TickerQ.Tests/SkipStaleCronOccurrencesTests.cs
+++ b/tests/TickerQ.Tests/SkipStaleCronOccurrencesTests.cs
@@ -26,6 +26,9 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
     private readonly List<Guid> _createdCronTickerIds = new();
     private readonly List<Guid> _createdOccurrenceIds = new();
 
+    /// <summary>Default threshold used in most tests (matches SchedulerOptionsBuilder default).</summary>
+    private static readonly TimeSpan DefaultThreshold = TimeSpan.FromSeconds(5);
+
     public SkipStaleCronOccurrencesTests()
     {
         _now = new DateTime(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
@@ -56,14 +59,12 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create an occurrence that is 10 seconds past-due (well beyond the 5s grace)
         var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
 
-        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(1, skipped);
 
-        // Verify it's now Skipped
         var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
         Assert.Single(all);
         Assert.Equal(TickerStatus.Skipped, all[0].Status);
@@ -76,10 +77,9 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create a Queued occurrence that is 10 seconds past-due
         var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Queued);
 
-        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(1, skipped);
 
@@ -94,10 +94,9 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create a future occurrence (30 seconds from now)
         var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(30), TickerStatus.Idle);
 
-        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(0, skipped);
 
@@ -112,10 +111,9 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create an occurrence that is only 2 seconds past-due (within 5s grace period)
         var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-2), TickerStatus.Idle);
 
-        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(0, skipped);
 
@@ -130,10 +128,9 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create a completed past-due occurrence
         var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-60), TickerStatus.Done);
 
-        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(0, skipped);
 
@@ -148,10 +145,9 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create an InProgress past-due occurrence (being actively processed by another node)
         var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-60), TickerStatus.InProgress);
 
-        var skipped = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(0, skipped);
 
@@ -168,11 +164,11 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
 
         await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
 
-        var first = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
-        var second = await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        var first = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
+        var second = await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
         Assert.Equal(1, first);
-        Assert.Equal(0, second); // Already Skipped, should not match again
+        Assert.Equal(0, second);
     }
 
     [Fact]
@@ -181,17 +177,78 @@ public class SkipStaleCronOccurrencesTests : IAsyncLifetime
         var cronTickerId = Guid.NewGuid();
         await SetupCronTicker(cronTickerId);
 
-        // Create a past-due Idle occurrence
         await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
 
-        // Skip stale occurrences
-        await _provider.SkipStaleCronOccurrencesAsync(CancellationToken.None);
+        await _provider.SkipStaleCronOccurrencesAsync(DefaultThreshold, CancellationToken.None);
 
-        // Fallback should find no timed-out occurrences
         var fallbackResults = await CollectAsync(
             _provider.QueueTimedOutCronTickerOccurrences(CancellationToken.None));
 
         Assert.Empty(fallbackResults);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_CustomThreshold_SkipsOlderOccurrences()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // 30 seconds past-due — stale under a 20-second threshold
+        var staleId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-30), TickerStatus.Idle);
+        // 10 seconds past-due — NOT stale under a 20-second threshold
+        var recentId = await InsertOccurrence(cronTickerId, _now.AddSeconds(-10), TickerStatus.Idle);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(TimeSpan.FromSeconds(20), CancellationToken.None);
+
+        Assert.Equal(1, skipped);
+
+        var stale = await _provider.GetAllCronTickerOccurrences(x => x.Id == staleId, CancellationToken.None);
+        Assert.Equal(TickerStatus.Skipped, stale[0].Status);
+
+        var recent = await _provider.GetAllCronTickerOccurrences(x => x.Id == recentId, CancellationToken.None);
+        Assert.Equal(TickerStatus.Idle, recent[0].Status);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_ZeroThreshold_SkipsNothing()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        // Even a very old occurrence should NOT be skipped when threshold is zero
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddMinutes(-60), TickerStatus.Idle);
+
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(TimeSpan.Zero, CancellationToken.None);
+
+        Assert.Equal(0, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Equal(TickerStatus.Idle, all[0].Status);
+    }
+
+    [Fact]
+    public void SchedulerOptionsBuilder_DefaultThreshold_IsZero_DisabledByDefault()
+    {
+        var options = new SchedulerOptionsBuilder();
+        Assert.Equal(TimeSpan.Zero, options.StaleCronOccurrenceThreshold);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_DisabledByDefault_DoesNotSkip()
+    {
+        var cronTickerId = Guid.NewGuid();
+        await SetupCronTicker(cronTickerId);
+
+        var occurrenceId = await InsertOccurrence(cronTickerId, _now.AddMinutes(-60), TickerStatus.Idle);
+
+        // Use the default threshold (Zero = disabled)
+        var defaultOptions = new SchedulerOptionsBuilder();
+        var skipped = await _provider.SkipStaleCronOccurrencesAsync(defaultOptions.StaleCronOccurrenceThreshold, CancellationToken.None);
+
+        Assert.Equal(0, skipped);
+
+        var all = await _provider.GetAllCronTickerOccurrences(x => x.Id == occurrenceId, CancellationToken.None);
+        Assert.Equal(TickerStatus.Idle, all[0].Status);
     }
 
     private async Task SetupCronTicker(Guid cronTickerId)

--- a/tests/TickerQ.Tests/TickerOptionsBuilderTests.cs
+++ b/tests/TickerQ.Tests/TickerOptionsBuilderTests.cs
@@ -154,6 +154,44 @@ public class TickerOptionsBuilderTests
     }
 
     [Fact]
+    public void SkipStaleCronOccurrencesOnStartup_DefaultThreshold_SetsFiveSeconds()
+    {
+        var executionContext = new TickerExecutionContext();
+        var schedulerOptions = new SchedulerOptionsBuilder();
+
+        var builder = new TickerOptionsBuilder<FakeTimeTicker, FakeCronTicker>(executionContext, schedulerOptions);
+
+        builder.SkipStaleCronOccurrencesOnStartup();
+
+        Assert.Equal(TimeSpan.FromSeconds(5), schedulerOptions.StaleCronOccurrenceThreshold);
+    }
+
+    [Fact]
+    public void SkipStaleCronOccurrencesOnStartup_CustomThreshold_SetsValue()
+    {
+        var executionContext = new TickerExecutionContext();
+        var schedulerOptions = new SchedulerOptionsBuilder();
+
+        var builder = new TickerOptionsBuilder<FakeTimeTicker, FakeCronTicker>(executionContext, schedulerOptions);
+
+        builder.SkipStaleCronOccurrencesOnStartup(TimeSpan.FromMinutes(2));
+
+        Assert.Equal(TimeSpan.FromMinutes(2), schedulerOptions.StaleCronOccurrenceThreshold);
+    }
+
+    [Fact]
+    public void SkipStaleCronOccurrencesOnStartup_NotCalled_ThresholdRemainsZero()
+    {
+        var executionContext = new TickerExecutionContext();
+        var schedulerOptions = new SchedulerOptionsBuilder();
+
+        // Don't call SkipStaleCronOccurrencesOnStartup
+        _ = new TickerOptionsBuilder<FakeTimeTicker, FakeCronTicker>(executionContext, schedulerOptions);
+
+        Assert.Equal(TimeSpan.Zero, schedulerOptions.StaleCronOccurrenceThreshold);
+    }
+
+    [Fact]
     public void DisableBackgroundServices_Sets_Flag_To_False()
     {
         var executionContext = new TickerExecutionContext();


### PR DESCRIPTION
## Summary

- At startup, past-due cron occurrences from a previous application lifecycle were caught up by the fallback service, causing the cron job to fire multiple times in quick succession
- Adds a startup cleanup step (`SkipStaleCronOccurrencesAsync`) that marks stale past-due occurrences as `Skipped` before the scheduler and fallback begin
- Uses a 5-second grace period so very recent occurrences (within 5s of restart) are preserved and handled normally by the main scheduler
- Skipped occurrences are visible in the dashboard with reason: "Missed: occurrence was pending when the application restarted"

## Changes

| File | Change |
|------|--------|
| `ITickerPersistenceProvider.cs` | Added `SkipStaleCronOccurrencesAsync` default interface method |
| `BasePersistenceProvider.cs` | EF Core implementation — bulk UPDATE to Skipped for stale Idle/Queued occurrences |
| `TickerInMemoryPersistenceProvider.cs` | In-memory implementation matching EF Core behavior |
| `IInternalTickerManager.cs` | Added method to internal manager interface |
| `InternalTickerManager.cs` | Delegates to persistence provider |
| `TickerQInitializerHostedService.cs` | Calls cleanup after cron ticker seeding, before scheduler starts |
| `SkipStaleCronOccurrencesTests.cs` | 8 unit tests covering skip/preserve/idempotency/fallback-integration |

## Design decisions

- **Not aggressive cleanup**: Only skips occurrences whose `ExecutionTime` is more than 5 seconds in the past. Recent occurrences within the grace window are left for the main scheduler or fallback to handle normally.
- **Visible, not silent**: Occurrences are marked `Skipped` with a descriptive `SkippedReason`, not deleted. Users can see exactly what happened in the dashboard.
- **Default interface method**: `SkipStaleCronOccurrencesAsync` uses a default no-op implementation on `ITickerPersistenceProvider` to avoid breaking custom persistence providers.
- **Runs before scheduler**: The cleanup runs in `TickerQInitializerHostedService.StartAsync` (after seeding), which is registered before the scheduler services — guaranteeing cleanup completes before any scheduling begins.

## Test plan

- [x] `SkipStaleCronOccurrences_SkipsPastDueIdleOccurrences` — Idle occurrence 10s past-due → Skipped
- [x] `SkipStaleCronOccurrences_SkipsPastDueQueuedOccurrences` — Queued occurrence 10s past-due → Skipped
- [x] `SkipStaleCronOccurrences_DoesNotSkipFutureOccurrences` — future occurrence → untouched
- [x] `SkipStaleCronOccurrences_DoesNotSkipRecentPastDueWithinGracePeriod` — 2s past-due → untouched (within 5s grace)
- [x] `SkipStaleCronOccurrences_DoesNotAffectCompletedOccurrences` — Done status → untouched
- [x] `SkipStaleCronOccurrences_DoesNotAffectInProgressOccurrences` — InProgress status → untouched
- [x] `SkipStaleCronOccurrences_IsIdempotent` — running twice skips 1 on first call, 0 on second
- [x] `SkipStaleCronOccurrences_SkippedOccurrencesNotPickedUpByFallback` — after skip, fallback finds nothing
- [x] Full test suite: 515/515 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)