### PR TITLE
Support external IConnectionMultiplexer for Redis DI

### DIFF
--- a/src/TickerQ.Caching.StackExchangeRedis/DependencyInjection/ServiceExtension.cs
+++ b/src/TickerQ.Caching.StackExchangeRedis/DependencyInjection/ServiceExtension.cs
@@ -27,14 +27,19 @@ public static class ServiceExtension
             };
             
             setupAction?.Invoke(options);
-            if (string.IsNullOrWhiteSpace(options.Configuration) && options.ConfigurationOptions == null && options.ConnectionMultiplexer == null)
+            if (string.IsNullOrWhiteSpace(options.Configuration)
+                && options.ConfigurationOptions == null
+                && options.ConnectionMultiplexer == null
+                && options.ConnectionMultiplexerFactory == null)
                 throw new InvalidOperationException("Redis configuration or connection must be provided when enabling StackExchange.Redis persistence.");
 
             services.AddKeyedSingleton<IConnectionMultiplexer>("tickerq", (_, _) =>
                 options.ConnectionMultiplexer
-                ?? (options.ConfigurationOptions != null
-                    ? ConnectionMultiplexer.Connect(options.ConfigurationOptions)
-                    : ConnectionMultiplexer.Connect(options.Configuration)));
+                ?? (options.ConnectionMultiplexerFactory != null
+                    ? options.ConnectionMultiplexerFactory().GetAwaiter().GetResult()
+                    : (options.ConfigurationOptions != null
+                        ? ConnectionMultiplexer.Connect(options.ConfigurationOptions)
+                        : ConnectionMultiplexer.Connect(options.Configuration))));
             services.AddKeyedSingleton<IDatabase>("tickerq", (sp, _) =>
                 sp.GetRequiredKeyedService<IConnectionMultiplexer>("tickerq").GetDatabase());
             services.AddHostedService<NodeHeartBeatBackgroundService>();

--- a/src/TickerQ.Caching.StackExchangeRedis/DependencyInjection/ServiceExtension.cs
+++ b/src/TickerQ.Caching.StackExchangeRedis/DependencyInjection/ServiceExtension.cs
@@ -27,17 +27,25 @@ public static class ServiceExtension
             };
             
             setupAction?.Invoke(options);
-            if (string.IsNullOrWhiteSpace(options.Configuration) && options.ConfigurationOptions == null)
-                throw new InvalidOperationException("Redis configuration must be provided when enabling StackExchange.Redis persistence.");
+            if (string.IsNullOrWhiteSpace(options.Configuration) && options.ConfigurationOptions == null && options.ConnectionMultiplexer == null)
+                throw new InvalidOperationException("Redis configuration or connection must be provided when enabling StackExchange.Redis persistence.");
 
-            services.AddSingleton<IConnectionMultiplexer>(_ =>
-                options.ConfigurationOptions != null
+            services.AddKeyedSingleton<IConnectionMultiplexer>("tickerq", (_, _) =>
+                options.ConnectionMultiplexer
+                ?? (options.ConfigurationOptions != null
                     ? ConnectionMultiplexer.Connect(options.ConfigurationOptions)
-                    : ConnectionMultiplexer.Connect(options.Configuration));
-            services.AddSingleton(sp => sp.GetRequiredService<IConnectionMultiplexer>().GetDatabase());
+                    : ConnectionMultiplexer.Connect(options.Configuration)));
+            services.AddKeyedSingleton<IDatabase>("tickerq", (sp, _) =>
+                sp.GetRequiredKeyedService<IConnectionMultiplexer>("tickerq").GetDatabase());
             services.AddHostedService<NodeHeartBeatBackgroundService>();
             services.AddSingleton<ITickerQRedisContext, TickerQRedisContext>();
-            services.AddKeyedSingleton<IDistributedCache>("tickerq", (sp, key) => new RedisCache(options));
+            services.AddKeyedSingleton<IDistributedCache>("tickerq", (sp, _) =>
+                new RedisCache(new RedisCacheOptions
+                {
+                    InstanceName = options.InstanceName,
+                    ConnectionMultiplexerFactory = () => Task.FromResult(
+                        sp.GetRequiredKeyedService<IConnectionMultiplexer>("tickerq")),
+                }));
             services.AddSingleton(_ => options);
             services.TryAddSingleton<ITickerPersistenceProvider<TTimeTicker, TCronTicker>, TickerRedisPersistenceProvider<TTimeTicker, TCronTicker>>();
         };
@@ -48,6 +56,14 @@ public static class ServiceExtension
     public class TickerQRedisOptionBuilder : RedisCacheOptions
     {
         public TimeSpan NodeHeartbeatInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// An existing <see cref="IConnectionMultiplexer"/> to use for all Redis operations.
+        /// When set, <see cref="RedisCacheOptions.Configuration"/> and
+        /// <see cref="RedisCacheOptions.ConfigurationOptions"/> are ignored.
+        /// The caller is responsible for the lifetime and disposal of the multiplexer.
+        /// </summary>
+        public IConnectionMultiplexer ConnectionMultiplexer { get; set; }
 
         /// <summary>
         /// Optional source-generated JsonSerializerContext for AOT compatibility.

--- a/src/TickerQ.Caching.StackExchangeRedis/Infrastructure/TickerRedisPersistenceProvider.cs
+++ b/src/TickerQ.Caching.StackExchangeRedis/Infrastructure/TickerRedisPersistenceProvider.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System.Linq.Expressions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using static TickerQ.Caching.StackExchangeRedis.DependencyInjection.ServiceExtension;
@@ -20,7 +21,7 @@ internal sealed class TickerRedisPersistenceProvider<TTimeTicker, TCronTicker> :
     where TCronTicker : CronTickerEntity, new()
 {
     public TickerRedisPersistenceProvider(
-        IDatabase db,
+        [FromKeyedServices("tickerq")] IDatabase db,
         ITickerClock clock,
         SchedulerOptionsBuilder optionsBuilder,
         TickerQRedisOptionBuilder redisOptions,

--- a/tests/TickerQ.Caching.StackExchangeRedis.Tests/DependencyInjection/ServiceExtensionTests.cs
+++ b/tests/TickerQ.Caching.StackExchangeRedis.Tests/DependencyInjection/ServiceExtensionTests.cs
@@ -136,6 +136,59 @@ public class ServiceExtensionTests
     }
 
     [Fact]
+    public void AddStackExchangeRedis_WithConnectionMultiplexerFactory_DoesNotThrow()
+    {
+        // ConnectionMultiplexerFactory is inherited from RedisCacheOptions. Callers who set
+        // only this property (the standard RedisCacheOptions pattern) must not hit the
+        // InvalidOperationException — validation must accept it as a fourth valid option.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var mockMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        var exception = Record.Exception(() =>
+        {
+            services.AddTickerQ(options =>
+            {
+                options.AddStackExchangeRedis(redis =>
+                {
+                    redis.ConnectionMultiplexerFactory = () => Task.FromResult(mockMultiplexer);
+                });
+            });
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithConnectionMultiplexerFactory_ResolvesInstanceFromFactory()
+    {
+        // The keyed IConnectionMultiplexer singleton must be built by invoking the factory
+        // (mirroring what Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache does
+        // in its sync Connect() path via .GetAwaiter().GetResult()).
+        // The resolved instance must be the exact one the factory returned.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var mockMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        services.AddTickerQ(options =>
+        {
+            options.AddStackExchangeRedis(redis =>
+            {
+                redis.ConnectionMultiplexerFactory = () => Task.FromResult(mockMultiplexer);
+            });
+        });
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredKeyedService<IConnectionMultiplexer>("tickerq");
+
+        Assert.True(ReferenceEquals(mockMultiplexer, resolved),
+            "The resolved keyed IConnectionMultiplexer should be the exact instance returned by ConnectionMultiplexerFactory.");
+    }
+
+
+    [Fact]
     public void AddStackExchangeRedis_WithConnectionMultiplexer_ResolvesProvidedInstance()
     {
         // TickerQRedisOptionBuilder had no ConnectionMultiplexer property,

--- a/tests/TickerQ.Caching.StackExchangeRedis.Tests/DependencyInjection/ServiceExtensionTests.cs
+++ b/tests/TickerQ.Caching.StackExchangeRedis.Tests/DependencyInjection/ServiceExtensionTests.cs
@@ -1,0 +1,213 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using StackExchange.Redis;
+using TickerQ.Caching.StackExchangeRedis.DependencyInjection;
+using TickerQ.DependencyInjection;
+
+namespace TickerQ.Caching.StackExchangeRedis.Tests.DependencyInjection;
+
+public class ServiceExtensionTests
+{
+    [Fact]
+    public void AddStackExchangeRedis_NoConfiguration_ThrowsInvalidOperation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // ExternalProviderConfigServiceAction is invoked inside AddTickerQ, so the exception
+        // is thrown there — not lazily during BuildServiceProvider.
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            // No Configuration, no ConfigurationOptions, no ConnectionMultiplexer
+            services.AddTickerQ(options =>
+            {
+                options.AddStackExchangeRedis(_ => { });
+            });
+        });
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithConfigurationString_DoesNotThrow()
+    {
+        // Regression: existing string-based configuration must still be accepted.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var exception = Record.Exception(() =>
+        {
+            services.AddTickerQ(options =>
+            {
+                options.AddStackExchangeRedis(redis =>
+                {
+                    redis.Configuration = "localhost:6379,abortConnect=false";
+                });
+            });
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithConnectionMultiplexer_DoesNotThrow()
+    {
+        // New capability: providing a pre-built IConnectionMultiplexer should be sufficient.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var mockMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        var exception = Record.Exception(() =>
+        {
+            services.AddTickerQ(options =>
+            {
+                options.AddStackExchangeRedis(redis =>
+                {
+                    redis.ConnectionMultiplexer = mockMultiplexer;
+                });
+            });
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithExistingMultiplexerInDI_PreservesExistingRegistration()
+    {
+        // Keyed services: TickerQ registers IConnectionMultiplexer under key "tickerq".
+        // It never touches the host app's unkeyed IConnectionMultiplexer slot.
+        // With the OLD code, AddSingleton (unkeyed) would have been appended — DI resolves the LAST
+        // descriptor, so the host's registration would be silently overridden. This proves it is not.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var preRegisteredMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        // Host app registers IConnectionMultiplexer BEFORE AddTickerQ
+        services.AddSingleton(preRegisteredMultiplexer);
+
+        services.AddTickerQ(options =>
+        {
+            options.AddStackExchangeRedis(redis =>
+            {
+                redis.Configuration = "localhost:6379,abortConnect=false";
+            });
+        });
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<IConnectionMultiplexer>();
+
+        // TickerQ must NOT have touched the unkeyed IConnectionMultiplexer slot
+        Assert.True(ReferenceEquals(preRegisteredMultiplexer, resolved),
+            "The pre-registered IConnectionMultiplexer was overridden. TickerQ should use its own keyed slot and leave the host's unkeyed registration untouched.");
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_HostAndTickerQMultiplexers_AreIndependentKeyedSlots()
+    {
+        // Proves that the host's unkeyed IConnectionMultiplexer and TickerQ's keyed one
+        // are completely independent — different instances, different DI slots.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var hostMultiplexer = Substitute.For<IConnectionMultiplexer>();
+        var tickerQMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        services.AddSingleton(hostMultiplexer);
+
+        services.AddTickerQ(options =>
+        {
+            options.AddStackExchangeRedis(redis =>
+            {
+                redis.ConnectionMultiplexer = tickerQMultiplexer;
+            });
+        });
+
+        var provider = services.BuildServiceProvider();
+        var resolvedHost = provider.GetRequiredService<IConnectionMultiplexer>();
+        var resolvedTickerQ = provider.GetRequiredKeyedService<IConnectionMultiplexer>("tickerq");
+
+        Assert.True(ReferenceEquals(hostMultiplexer, resolvedHost),
+            "The host's unkeyed IConnectionMultiplexer should be unchanged.");
+        Assert.True(ReferenceEquals(tickerQMultiplexer, resolvedTickerQ),
+            "TickerQ's keyed IConnectionMultiplexer should be the instance passed via options.");
+        Assert.False(ReferenceEquals(resolvedHost, resolvedTickerQ),
+            "Host and TickerQ multiplexers must be independent — different instances.");
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithConnectionMultiplexer_ResolvesProvidedInstance()
+    {
+        // TickerQRedisOptionBuilder had no ConnectionMultiplexer property,
+        // so there was no way to pass a pre-built multiplexer at all.
+        // The fix adds the property and registers it under the "tickerq" keyed slot.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var mockMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        services.AddTickerQ(options =>
+        {
+            options.AddStackExchangeRedis(redis =>
+            {
+                redis.ConnectionMultiplexer = mockMultiplexer;
+            });
+        });
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredKeyedService<IConnectionMultiplexer>("tickerq");
+
+        Assert.True(ReferenceEquals(mockMultiplexer, resolved),
+            "The resolved keyed IConnectionMultiplexer should be the exact instance passed via options.ConnectionMultiplexer.");
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithConnectionMultiplexer_RegistersKeyedDistributedCache()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var mockMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        services.AddTickerQ(options =>
+        {
+            options.AddStackExchangeRedis(redis =>
+            {
+                redis.ConnectionMultiplexer = mockMultiplexer;
+            });
+        });
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IDistributedCache) &&
+            d.IsKeyedService &&
+            d.ServiceKey is "tickerq");
+
+        Assert.NotNull(descriptor);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddStackExchangeRedis_WithConnectionMultiplexer_RegistersIConnectionMultiplexerAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var mockMultiplexer = Substitute.For<IConnectionMultiplexer>();
+
+        services.AddTickerQ(options =>
+        {
+            options.AddStackExchangeRedis(redis =>
+            {
+                redis.ConnectionMultiplexer = mockMultiplexer;
+            });
+        });
+
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConnectionMultiplexer) &&
+            d.IsKeyedService &&
+            d.ServiceKey is "tickerq");
+
+        Assert.NotNull(descriptor);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+}


### PR DESCRIPTION
Add ConnectionMultiplexer property to TickerQRedisOptionBuilder, allowing use of a pre-built multiplexer. 
Register all Redis services as keyed singletons under "tickerq" to avoid conflicts with host DI (TickerQ was silently overwriting existing IConnectionMultiplexer registrations). 
Update TickerRedisPersistenceProvider to use keyed injection. 
Add tests for configuration, registration, and service independence. 
Docs update in other repo. 

#802 