### PR TITLE
Add server-side status and search filters to time-tickers dashboard (#718)

### DIFF
--- a/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
+++ b/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
@@ -320,7 +320,12 @@ public static class DashboardEndpoints
         int.TryParse(context.Request.Query["pageSize"].ToString(), out var pageSize);
         if (pageSize < 1) pageSize = 20;
 
-        var result = await repository.GetTimeTickersPaginatedAsync(pageNumber, pageSize, cancellationToken);
+        TickerStatus? status = Enum.TryParse<TickerStatus>(context.Request.Query["status"].ToString(), ignoreCase: true, out var parsedStatus)
+            ? parsedStatus
+            : null;
+        var search = context.Request.Query["search"].ToString();
+
+        var result = await repository.GetTimeTickersPaginatedAsync(pageNumber, pageSize, status, search, cancellationToken);
         await WriteJson(context, result, dashboardOptions.DashboardJsonOptions);
     }
 

--- a/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/Dashboard/TickerDashboardRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,8 +43,30 @@ namespace TickerQ.Dashboard.Infrastructure.Dashboard
         public async Task<TTimeTicker[]> GetTimeTickersAsync(CancellationToken cancellationToken)
             => await _persistenceProvider.GetTimeTickers(null, cancellationToken);
         
-        public async Task<PaginationResult<TTimeTicker>> GetTimeTickersPaginatedAsync(int pageNumber, int pageSize, CancellationToken cancellationToken)
-            => await _persistenceProvider.GetTimeTickersPaginated(null, pageNumber, pageSize, cancellationToken);
+        public async Task<PaginationResult<TTimeTicker>> GetTimeTickersPaginatedAsync(int pageNumber, int pageSize, TickerStatus? status = null, string search = null, CancellationToken cancellationToken = default)
+        {
+            var predicate = BuildTimeTickerFilter(status, search);
+            return await _persistenceProvider.GetTimeTickersPaginated(predicate, pageNumber, pageSize, cancellationToken);
+        }
+
+        internal static Expression<Func<TTimeTicker, bool>> BuildTimeTickerFilter(TickerStatus? status, string search)
+        {
+            var term = string.IsNullOrWhiteSpace(search) ? null : search;
+
+            if (status is { } s && term is not null)
+                return x => x.Status == s &&
+                    ((x.Function != null && x.Function.Contains(term)) ||
+                     (x.ExceptionMessage != null && x.ExceptionMessage.Contains(term)));
+
+            if (status is { } statusOnly)
+                return x => x.Status == statusOnly;
+
+            if (term is not null)
+                return x => (x.Function != null && x.Function.Contains(term)) ||
+                            (x.ExceptionMessage != null && x.ExceptionMessage.Contains(term));
+
+            return null;
+        }
 
         public async Task<IList<Tuple<TickerStatus, int>>> GetTimeTickerFullDataAsync(CancellationToken cancellationToken)
         {

--- a/src/TickerQ.Dashboard/wwwroot/src/__tests__/timeTickerService.test.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/__tests__/timeTickerService.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRequest = vi.fn().mockResolvedValue({ data: { items: [], totalCount: 0 }, headers: {} });
+
+vi.mock('axios', () => {
+    const CancelToken = { source: () => ({ token: {}, cancel: vi.fn() }) };
+    return {
+        default: {
+            create: () => ({
+                request: mockRequest,
+                interceptors: {
+                    request: { use: vi.fn() },
+                    response: { use: vi.fn() },
+                },
+            }),
+            CancelToken: Object.assign(function (executor: (cancel: Function) => void) {
+                executor(vi.fn());
+            }, { source: CancelToken.source }),
+        },
+        AxiosError: class AxiosError extends Error {},
+    };
+});
+
+vi.mock('vue', () => ({
+    ref: (val: any) => ({ value: val }),
+}));
+
+vi.mock('@/composables/useAlert', () => ({
+    useAlert: () => ({ showHttpError: vi.fn() }),
+}));
+
+vi.mock('@/stores/authStore', () => ({
+    useAuthStore: () => ({ handle401Error: vi.fn() }),
+}));
+vi.mock('@/stores/alertStore', () => ({
+    useAlertStore: () => ({ showHttpError: vi.fn() }),
+}));
+vi.mock('@/stores/functionNames', () => ({
+    useFunctionNameStore: () => ({ getNamespaceOrNull: () => null }),
+}));
+vi.mock('@/stores/timeZoneStore', () => ({
+    useTimeZoneStore: () => ({ effectiveTimeZone: 'UTC' }),
+}));
+
+vi.mock('@/utilities/pathResolver', () => ({
+    getApiBaseUrl: () => '/api',
+    getAuthMode: () => 'none',
+}));
+
+vi.mock('@/http/services/types/base/baseHttpResponse.types', () => ({
+    getStatusValueSafe: (v: any) => v,
+    Status: {},
+}));
+
+describe('timeTickerService.getTimeTickersPaginated', () => {
+    beforeEach(() => {
+        mockRequest.mockClear();
+        mockRequest.mockResolvedValue({ data: { items: [], totalCount: 0 }, headers: {} });
+    });
+
+    it('omits status and search when not provided', async () => {
+        const { timeTickerService } = await import('@/http/services/timeTickerService');
+        const svc = timeTickerService.getTimeTickersPaginated();
+
+        await svc.requestAsync(1, 20);
+
+        expect(mockRequest).toHaveBeenCalledTimes(1);
+        expect(mockRequest.mock.calls[0][0].params).toEqual({ pageNumber: 1, pageSize: 20 });
+    });
+
+    it('forwards status and search when provided', async () => {
+        const { timeTickerService } = await import('@/http/services/timeTickerService');
+        const svc = timeTickerService.getTimeTickersPaginated();
+
+        await svc.requestAsync(2, 10, 'Failed', 'timeout');
+
+        expect(mockRequest.mock.calls[0][0].params).toEqual({
+            pageNumber: 2,
+            pageSize: 10,
+            status: 'Failed',
+            search: 'timeout',
+        });
+    });
+
+    it('omits empty-string search even if explicitly passed', async () => {
+        const { timeTickerService } = await import('@/http/services/timeTickerService');
+        const svc = timeTickerService.getTimeTickersPaginated();
+
+        await svc.requestAsync(1, 20, undefined, '');
+
+        expect(mockRequest.mock.calls[0][0].params).toEqual({ pageNumber: 1, pageSize: 20 });
+    });
+});

--- a/src/TickerQ.Dashboard/wwwroot/src/http/services/timeTickerService.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/http/services/timeTickerService.ts
@@ -143,10 +143,16 @@ const getTimeTickersPaginated = () => {
             return response;
     };
     
-    const requestAsync = async (pageNumber: number = 1, pageSize: number = 20) => {
-        const response = await baseHttp.sendAsync("GET", "time-tickers/paginated", { 
-            paramData: { pageNumber, pageSize } 
-        });
+    const requestAsync = async (
+        pageNumber: number = 1,
+        pageSize: number = 20,
+        status?: string,
+        search?: string
+    ) => {
+        const paramData: Record<string, string | number> = { pageNumber, pageSize };
+        if (status) paramData.status = status;
+        if (search) paramData.search = search;
+        const response = await baseHttp.sendAsync("GET", "time-tickers/paginated", { paramData });
         return processResponse(response);
     };
     

--- a/src/TickerQ.Dashboard/wwwroot/src/views/TimeTicker.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/views/TimeTicker.vue
@@ -78,7 +78,10 @@ const chainJobsModal = ref({
 })
 
 const expandedParents = ref(new Set<string>())
-const tableSearch = ref('')
+// Server-side filters: input is staged, only the active term is sent to the API.
+const filterSearchInput = ref<string | null>('')
+const filterSearchActive = ref('')
+const filterStatus = ref<string | null>(null)
 
 const selectedItems = ref(new Set<string>())
 
@@ -156,7 +159,12 @@ onUnmounted(() => {
 // Load page data with pagination
 const loadPageData = async () => {
   try {
-    const response = await getTimeTickersPaginated.requestAsync(currentPage.value, pageSize.value)
+    const response = await getTimeTickersPaginated.requestAsync(
+      currentPage.value,
+      pageSize.value,
+      filterStatus.value ?? undefined,
+      filterSearchActive.value || undefined,
+    )
     if (response) {
       totalCount.value = response.totalCount || 0
     }
@@ -171,12 +179,49 @@ const handlePageChange = async (page: number) => {
   await loadPageData()
 }
 
-// Handle page size change  
+// Handle page size change
 const handlePageSizeChange = async (size: number) => {
   pageSize.value = size
   currentPage.value = 1  // Reset to first page when changing page size
   await loadPageData()
 }
+
+const applyFilters = async () => {
+  filterSearchActive.value = (filterSearchInput.value ?? '').trim()
+  currentPage.value = 1
+  await loadPageData()
+}
+
+// Auto-apply only when the input transitions to empty so the visible field
+// can never disagree with the term currently sent to the API.
+watch(filterSearchInput, (next, prev) => {
+  const wasEmpty = !(prev ?? '').trim()
+  const isEmpty = !(next ?? '').trim()
+  if (!wasEmpty && isEmpty && filterSearchActive.value !== '') {
+    applyFilters()
+  }
+})
+
+const clearFilters = async () => {
+  filterSearchInput.value = ''
+  filterSearchActive.value = ''
+  filterStatus.value = null
+  currentPage.value = 1
+  await loadPageData()
+}
+
+// Mirrors the TickerStatus enum order.
+const statusFilterOptions = [
+  { value: null, title: 'All statuses' },
+  { value: 'Idle', title: 'Idle' },
+  { value: 'Queued', title: 'Queued' },
+  { value: 'InProgress', title: 'In Progress' },
+  { value: 'Done', title: 'Done' },
+  { value: 'DueDone', title: 'Due Done' },
+  { value: 'Failed', title: 'Failed' },
+  { value: 'Cancelled', title: 'Cancelled' },
+  { value: 'Skipped', title: 'Skipped' },
+]
 
 // Chart data loading functions
 const loadTimeSeriesChartData = async (min: number, max: number) => {
@@ -1008,15 +1053,52 @@ const canBeForceDeleted = ref<string[]>([])
             <!-- Search and Info Group -->
             <div class="search-info-group">
               <v-text-field
-                v-model="tableSearch"
+                v-model="filterSearchInput"
                 prepend-inner-icon="mdi-magnify"
-                label="Search tickers..."
+                label="Search Function / Error..."
                 variant="outlined"
                 density="compact"
                 hide-details
-                style="width: 200px"
+                clearable
+                style="width: 240px"
                 class="search-field"
+                @keyup.enter="applyFilters"
               ></v-text-field>
+
+              <v-select
+                v-model="filterStatus"
+                :items="statusFilterOptions"
+                item-title="title"
+                item-value="value"
+                label="Status"
+                variant="outlined"
+                density="compact"
+                hide-details
+                style="width: 160px"
+                @update:modelValue="applyFilters"
+              ></v-select>
+
+              <v-btn
+                size="small"
+                variant="tonal"
+                color="primary"
+                prepend-icon="mdi-magnify"
+                :disabled="getTimeTickersPaginated.loader.value"
+                @click="applyFilters"
+              >
+                Search
+              </v-btn>
+
+              <v-btn
+                v-if="filterSearchActive || filterStatus"
+                size="small"
+                variant="text"
+                prepend-icon="mdi-close"
+                :disabled="getTimeTickersPaginated.loader.value"
+                @click="clearFilters"
+              >
+                Clear
+              </v-btn>
 
               <v-chip
                 :color="getTimeTickersPaginated.loader.value ? 'warning' : 'success'"
@@ -1095,7 +1177,6 @@ const canBeForceDeleted = ref<string[]>([])
             item-value="Id"
             :items-per-page="-1"
             class="enhanced-table dense-table"
-            :search="tableSearch"
             hide-default-footer
             :item-height="32"
           >

--- a/src/TickerQ.Utilities/Interfaces/ITickerDashboardRepository.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerDashboardRepository.cs
@@ -14,7 +14,7 @@ namespace TickerQ.Utilities.Interfaces
         where TCronTicker : CronTickerEntity, new()
     {
         Task<TTimeTicker[]> GetTimeTickersAsync(CancellationToken cancellationToken = default);
-        Task<PaginationResult<TTimeTicker>> GetTimeTickersPaginatedAsync(int pageNumber, int pageSize, CancellationToken cancellationToken = default);
+        Task<PaginationResult<TTimeTicker>> GetTimeTickersPaginatedAsync(int pageNumber, int pageSize, TickerStatus? status = null, string search = null, CancellationToken cancellationToken = default);
         Task<IList<Tuple<TickerStatus, int>>> GetTimeTickerFullDataAsync(CancellationToken cancellationToken);
         Task<IList<TickerGraphData>> GetTimeTickersGraphSpecificDataAsync(int pastDays, int futureDays,CancellationToken cancellationToken);
         Task<IList<TickerGraphData>> GetCronTickersGraphSpecificDataAsync(int pastDays, int futureDays,CancellationToken cancellationToken);

--- a/tests/TickerQ.Tests/TimeTickerFilterTests.cs
+++ b/tests/TickerQ.Tests/TimeTickerFilterTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using TickerQ.Dashboard.Infrastructure.Dashboard;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using Xunit;
+
+namespace TickerQ.Tests;
+
+public class TimeTickerFilterTests
+{
+    private static TimeTickerEntity Ticker(TickerStatus status, string function = null, string exceptionMessage = null)
+        => new() { Status = status, Function = function, ExceptionMessage = exceptionMessage };
+
+    [Fact]
+    public void BuildTimeTickerFilter_NoFilters_ReturnsNull()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(status: null, search: null);
+
+        Assert.Null(predicate);
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_WhitespaceSearch_TreatedAsNoSearch()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(status: null, search: "   ");
+
+        Assert.Null(predicate);
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_StatusOnly_MatchesByStatus()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(TickerStatus.Failed, search: null)
+            .Compile();
+
+        Assert.True(predicate(Ticker(TickerStatus.Failed)));
+        Assert.False(predicate(Ticker(TickerStatus.Done)));
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_SearchOnly_MatchesFunctionSubstring()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(status: null, search: "Order")
+            .Compile();
+
+        Assert.True(predicate(Ticker(TickerStatus.Done, function: "ProcessOrder")));
+        Assert.False(predicate(Ticker(TickerStatus.Done, function: "ProcessPayment")));
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_SearchOnly_MatchesExceptionMessageSubstring()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(status: null, search: "timeout")
+            .Compile();
+
+        Assert.True(predicate(Ticker(TickerStatus.Failed, function: "DoWork", exceptionMessage: "Connection timeout after 30s")));
+        Assert.False(predicate(Ticker(TickerStatus.Failed, function: "DoWork", exceptionMessage: "Permission denied")));
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_SearchOnly_HandlesNullFunctionAndExceptionMessage()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(status: null, search: "anything")
+            .Compile();
+
+        Assert.False(predicate(Ticker(TickerStatus.Done, function: null, exceptionMessage: null)));
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_StatusAndSearch_BothMustMatch()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(TickerStatus.Failed, search: "timeout")
+            .Compile();
+
+        Assert.True(predicate(Ticker(TickerStatus.Failed, exceptionMessage: "request timeout")));
+        Assert.False(predicate(Ticker(TickerStatus.Done, exceptionMessage: "request timeout")));
+        Assert.False(predicate(Ticker(TickerStatus.Failed, exceptionMessage: "other error")));
+    }
+
+    [Fact]
+    public void BuildTimeTickerFilter_SearchOnly_MatchesAcrossEitherColumn()
+    {
+        var predicate = TickerDashboardRepository<TimeTickerEntity, CronTickerEntity>
+            .BuildTimeTickerFilter(status: null, search: "shared")
+            .Compile();
+
+        Assert.True(predicate(Ticker(TickerStatus.Done, function: "sharedJob", exceptionMessage: null)));
+        Assert.True(predicate(Ticker(TickerStatus.Failed, function: "DoWork", exceptionMessage: "shared lock contention")));
+    }
+}


### PR DESCRIPTION
## Summary

Adds two optional query parameters — `status` and `search` — to `GET /api/time-tickers/paginated`, replacing the dashboard's previous client-side search (which only filtered the rows already loaded on the current page and was unusable on installations with thousands of records).

```
GET /api/time-tickers/paginated?status=Failed&search=timeout
```

## Why

Looking for a specific failure or job by substring required scrolling page-by-page; the existing search worked only within the current page. See #718, #459 for the user-side requests.

## What changed

**Backend.** The paginated endpoint now accepts an optional `TickerStatus` and free-text term, applied as a server-side predicate that combines status equality with a substring match on `Function` or `ExceptionMessage`. When neither filter is provided the request behaves exactly as before. Invalid status values are silently ignored for forward compatibility.

**Frontend.** The client-side filter has been replaced with:
- a status dropdown that auto-applies on change,
- a free-text input that applies on Enter / Search button / when cleared,
- a Clear button to reset both filters,
- pagination resets to page 1 on every filter change.

The existing list loading indicator is reused.

## Filter trigger behaviour

The two filters apply differently by design:

- **Status dropdown** — auto-applies on change. The value is discrete (one click selects it), so an immediate fetch keeps the UI feeling responsive without risk of wasted requests.
- **Free-text search** — applies only on `Enter`, on the Search button, or when the field is cleared. Auto-applying on every keystroke (even debounced) would fire repeated `LIKE %term%` queries while the user is still typing, each potentially scanning the whole table. Requiring an explicit confirmation lets the user shape the query first and pay the cost once.

## Screenshots

**New filter toolbar:**
<img width="1421" height="483" alt="image" src="https://github.com/user-attachments/assets/90492b34-7b89-4ff4-8e9a-2829cd0328ef" />

**Status filter applied:**

<img width="1421" height="483" alt="image" src="https://github.com/user-attachments/assets/c3931730-08dd-4f5b-ab75-d6e561039535" />

## Notes on case sensitivity

Search semantics follow each backend's own collation, consistent with how the rest of TickerQ's predicates already behave:

| Backend | `Contains` |
|---|---|
| SQL Server / SQLite (ASCII) / MySQL | case-insensitive (default collation) |
| PostgreSQL | case-sensitive (default `LIKE`) |
| Redis (in-memory compiled predicate) | case-sensitive (.NET `String.Contains`) |

## Tests

- **`TimeTickerFilterTests`** — 8 unit tests on the new predicate builder covering all combinations of status / search / nulls.
- **`timeTickerService.test`** — 3 frontend tests verifying that the new query parameters are forwarded only when set.

All gating test suites pass in `Release` (xUnit + vitest).

## Validation on real data

Smoke-tested end-to-end on **SQL Server** and **SQLite** with **50 000 seeded rows** (same distribution: ~14 % `Failed` with synthetic `ExceptionMessage`, rest split across `Done` / `Cancelled` / `Skipped`).

End-to-end API latency (single curl run per query):

| Query | SQL Server | SQLite | Match |
|---|---|---|---|
| no filter | 107 ms | 211 ms | ~50 000 |
| status=`Failed` | **49 ms** | 128 ms | ~7 143 |
| status=`Failed` + search=`timeout` | **47 ms** | 124 ms | ~7 143 |
| search=`timeout` | 245 ms | 161 ms | ~7 143 |
| search=`db-42` | 91 ms | 128 ms | 72 |
| status=`Done` + search=`Order` | 31 ms | 117 ms | ~5 715 |
| search=`NoMatchAtAll` | 160 ms | 10 ms | 0 |

> Numbers are single-shot and intended as a sanity check on the order of magnitude, not a rigorous benchmark. The takeaway is that filter behaviour is correct on both backends and latency stays well within dashboard tolerance.

Status filters benefit from the existing `IX_TimeTicker_Status_ExecutionTime` index → fastest queries.

Closes #718
Related to #459
