### PR TITLE
Fix empty time-series chart on dashboard graph-data-range endpoints

### DIFF
--- a/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
+++ b/src/TickerQ.Dashboard/Endpoints/DashboardEndpoints.cs
@@ -332,10 +332,10 @@ public static class DashboardEndpoints
         var dashboardOptions = context.RequestServices.GetRequiredService<DashboardOptionsBuilder>();
         var cancellationToken = context.RequestAborted;
 
-        int.TryParse(context.Request.Query["pastDays"].ToString(), out var pastDays);
-        if (pastDays < 1) pastDays = 3;
-        int.TryParse(context.Request.Query["futureDays"].ToString(), out var futureDays);
-        if (futureDays < 1) futureDays = 3;
+        if (!int.TryParse(context.Request.Query["pastDays"].ToString(), out var pastDays))
+            pastDays = -3;
+        if (!int.TryParse(context.Request.Query["futureDays"].ToString(), out var futureDays))
+            futureDays = 3;
 
         var result = await repository.GetTimeTickersGraphSpecificDataAsync(pastDays, futureDays, cancellationToken);
         await WriteJson(context, result, dashboardOptions.DashboardJsonOptions);
@@ -502,10 +502,10 @@ public static class DashboardEndpoints
         var dashboardOptions = context.RequestServices.GetRequiredService<DashboardOptionsBuilder>();
         var cancellationToken = context.RequestAborted;
 
-        int.TryParse(context.Request.Query["pastDays"].ToString(), out var pastDays);
-        if (pastDays < 1) pastDays = 3;
-        int.TryParse(context.Request.Query["futureDays"].ToString(), out var futureDays);
-        if (futureDays < 1) futureDays = 3;
+        if (!int.TryParse(context.Request.Query["pastDays"].ToString(), out var pastDays))
+            pastDays = -3;
+        if (!int.TryParse(context.Request.Query["futureDays"].ToString(), out var futureDays))
+            futureDays = 3;
 
         var result = await repository.GetCronTickersGraphSpecificDataAsync(pastDays, futureDays, cancellationToken);
         await WriteJson(context, result, dashboardOptions.DashboardJsonOptions);
@@ -520,10 +520,10 @@ public static class DashboardEndpoints
         var cancellationToken = context.RequestAborted;
 
         var id = Guid.Parse(context.Request.Query["id"].ToString());
-        int.TryParse(context.Request.Query["pastDays"].ToString(), out var pastDays);
-        if (pastDays < 1) pastDays = 3;
-        int.TryParse(context.Request.Query["futureDays"].ToString(), out var futureDays);
-        if (futureDays < 1) futureDays = 3;
+        if (!int.TryParse(context.Request.Query["pastDays"].ToString(), out var pastDays))
+            pastDays = -3;
+        if (!int.TryParse(context.Request.Query["futureDays"].ToString(), out var futureDays))
+            futureDays = 3;
 
         var result = await repository.GetCronTickersGraphSpecificDataByIdAsync(id, pastDays, futureDays, cancellationToken);
         await WriteJson(context, result, dashboardOptions.DashboardJsonOptions);


### PR DESCRIPTION
## Summary

Fixes #822 — the Time Series chart on the Cron Tickers page renders empty (flat at 0) on 10.3.0.

The same issue affects the Time Tickers chart: both are fixed in one place.

## What seems to cause it

The frontend calls these endpoints with `pastDays=-3` to look into the past. A guard added in the recent endpoint rewrite turns any value below 1 into 3, so `-3` becomes `3` and the query window collapses to a single future day with no data.

## Fix

Apply the default only when the value is unparseable, so explicit (including negative) values pass through unchanged. No frontend or repository changes — the wire contract is unchanged.

## Verification

Reproduced locally on the sample WebApi against SQL Server. Before the fix the endpoint returned a single date with all-zero series; after the fix it returns the full 7-day window with real status counts, and the chart renders correctly.