### PR TITLE
Refactor JSON serialization for SignalR/dashboard APIs

### DIFF
--- a/src/TickerQ.Caching.StackExchangeRedis/Properties/InternalsVisibleTo.cs
+++ b/src/TickerQ.Caching.StackExchangeRedis/Properties/InternalsVisibleTo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TickerQ.Caching.StackExchangeRedis.Tests")]
+[assembly: InternalsVisibleTo("TickerQ.Tests")]

--- a/src/TickerQ.Caching.StackExchangeRedis/TickerQRedisContext.cs
+++ b/src/TickerQ.Caching.StackExchangeRedis/TickerQRedisContext.cs
@@ -39,7 +39,8 @@ internal class TickerQRedisContext : ITickerQRedisContext
             Ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), Node = node
         };
 
-        await _notificationHubSender.UpdateNodeHeartBeatAsync(payload);
+        var jsonElement = JsonSerializer.SerializeToElement(payload, RedisContextJsonSerializerContext.Default.NodeHeartbeatPayload);
+        await _notificationHubSender.UpdateNodeHeartBeatAsync(jsonElement);
 
         var interval = _tickerQRedisOptionBuilder.NodeHeartbeatInterval;
         var ttl      = TimeSpan.FromSeconds(interval.TotalSeconds + 20);
@@ -167,6 +168,7 @@ internal sealed class NodeHeartbeatPayload
 [JsonSerializable(typeof(TimeTickerEntity))]
 [JsonSerializable(typeof(TimeTickerEntity[]))]
 [JsonSerializable(typeof(List<TimeTickerEntity>))]
+[JsonSerializable(typeof(ICollection<TimeTickerEntity>))]
 [JsonSerializable(typeof(CronTickerEntity))]
 [JsonSerializable(typeof(CronTickerEntity[]))]
 [JsonSerializable(typeof(CronTickerOccurrenceEntity<CronTickerEntity>))]

--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -34,20 +34,8 @@ namespace TickerQ.Dashboard.DependencyInjection
             // Register the dashboard configuration for DI
             services.AddSingleton(config);
 
-            // Register source-generated context into ASP.NET's HTTP JSON options
-            // so minimal API endpoint parameter binding works with reflection disabled
-            services.ConfigureHttpJsonOptions(options =>
-            {
-                options.SerializerOptions.TypeInfoResolverChain.Insert(0, DashboardJsonSerializerContext.Default);
-            });
-
             services.AddRouting();
-            services.AddSignalR()
-                .AddJsonProtocol(options =>
-                {
-                    options.PayloadSerializerOptions.TypeInfoResolverChain
-                        .Add(DashboardJsonSerializerContext.Default);
-                });
+            services.AddSignalR();
 
             // The new authentication system is registered in ServiceExtensions.cs
             // This method is kept for backward compatibility with existing middleware pipeline

--- a/src/TickerQ.Dashboard/Hubs/CronOccurrenceUpdateNotification.cs
+++ b/src/TickerQ.Dashboard/Hubs/CronOccurrenceUpdateNotification.cs
@@ -1,0 +1,16 @@
+using System;
+using TickerQ.Utilities.Enums;
+
+namespace TickerQ.Dashboard.Hubs
+{
+    internal sealed class CronOccurrenceUpdateNotification
+    {
+        public Guid Id { get; set; }
+        public TickerStatus Status { get; set; }
+        public Guid? CronTickerId { get; set; }
+        public DateTime ExecutedAt { get; set; }
+        public long ElapsedTime { get; set; }
+        public int RetryCount { get; set; }
+        public string ExceptionMessage { get; set; }
+    }
+}

--- a/src/TickerQ.Dashboard/Hubs/TickerQNotificationHubSender.cs
+++ b/src/TickerQ.Dashboard/Hubs/TickerQNotificationHubSender.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using TickerQ.Dashboard.Infrastructure;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Interfaces;
 using TickerQ.Utilities.Models;
@@ -23,12 +25,14 @@ namespace TickerQ.Dashboard.Hubs
 
         public async Task AddCronTickerNotifyAsync(object cronTicker)
         {
-            await _hubContext.Clients.All.SendAsync("AddCronTickerNotification", cronTicker);
+            var json = JsonSerializer.SerializeToElement((CronTickerEntity)cronTicker, DashboardJsonSerializerContext.Default.CronTickerEntity);
+            await _hubContext.Clients.All.SendAsync("AddCronTickerNotification", json);
         }
 
         public async Task UpdateCronTickerNotifyAsync(object cronTicker)
         {
-            await _hubContext.Clients.All.SendAsync("UpdateCronTickerNotification", cronTicker);
+            var json = JsonSerializer.SerializeToElement((CronTickerEntity)cronTicker, DashboardJsonSerializerContext.Default.CronTickerEntity);
+            await _hubContext.Clients.All.SendAsync("UpdateCronTickerNotification", json);
         }
 
         public async Task RemoveCronTickerNotifyAsync(Guid id)
@@ -48,7 +52,8 @@ namespace TickerQ.Dashboard.Hubs
 
         public async Task UpdateTimeTickerNotifyAsync(object timeTicker)
         {
-            await _hubContext.Clients.All.SendAsync("UpdateTimeTickerNotification", timeTicker);
+            var json = JsonSerializer.SerializeToElement((TimeTickerEntity)timeTicker, DashboardJsonSerializerContext.Default.TimeTickerEntity);
+            await _hubContext.Clients.All.SendAsync("UpdateTimeTickerNotification", json);
         }
 
         public async Task RemoveTimeTickerNotifyAsync(Guid id)
@@ -56,40 +61,48 @@ namespace TickerQ.Dashboard.Hubs
             await _hubContext.Clients.All.SendAsync("RemoveTimeTickerNotification", id);
         }
 
-        public void UpdateActiveThreads(object activeThreads)
+        public void UpdateActiveThreads(string activeThreads)
         {
-            _ = _hubContext.Clients.All.SendAsync("GetActiveThreadsNotification", activeThreads);
+            var json = JsonSerializer.SerializeToElement(activeThreads, DashboardJsonSerializerContext.Default.String);
+            _ = _hubContext.Clients.All.SendAsync("GetActiveThreadsNotification", json);
         }
 
-        public void UpdateNextOccurrence(object nextOccurrence)
+        public void UpdateNextOccurrence(DateTime? nextOccurrence)
         {
-            if(nextOccurrence != null)
-                _ = _hubContext.Clients.All.SendAsync("GetNextOccurrenceNotification", nextOccurrence);
+            if (nextOccurrence != null)
+            {
+                var json = JsonSerializer.SerializeToElement(nextOccurrence, DashboardJsonSerializerContext.Default.NullableDateTime);
+                _ = _hubContext.Clients.All.SendAsync("GetNextOccurrenceNotification", json);
+            }
         }
 
-        public void UpdateHostStatus(object active)
+        public void UpdateHostStatus(bool active)
         {
-            _ = _hubContext.Clients.All.SendAsync("GetHostStatusNotification", active);
+            var json = JsonSerializer.SerializeToElement(active, DashboardJsonSerializerContext.Default.Boolean);
+            _ = _hubContext.Clients.All.SendAsync("GetHostStatusNotification", json);
         }
 
-        public void UpdateHostException(object exceptionMessage)
+        public void UpdateHostException(string exceptionMessage)
         {
-            _ = _hubContext.Clients.All.SendAsync("UpdateHostExceptionNotification", exceptionMessage);
+            var json = JsonSerializer.SerializeToElement(exceptionMessage, DashboardJsonSerializerContext.Default.String);
+            _ = _hubContext.Clients.All.SendAsync("UpdateHostExceptionNotification", json);
         }
 
-        public async Task UpdateNodeHeartBeatAsync(object nodeHeartBeat)
+        public async Task UpdateNodeHeartBeatAsync(JsonElement nodeHeartBeat)
         {
             await _hubContext.Clients.All.SendAsync("UpdateNodeHeartBeat", nodeHeartBeat);
         }
 
         public async Task AddCronOccurrenceAsync(Guid groupId, object occurrence)
         {
-            await _hubContext.Clients.Group(groupId.ToString()).SendAsync("AddCronOccurrenceNotification", occurrence);
+            var json = JsonSerializer.SerializeToElement((CronTickerOccurrenceEntity<CronTickerEntity>)occurrence, DashboardJsonSerializerContext.Default.CronTickerOccurrenceEntityCronTickerEntity);
+            await _hubContext.Clients.Group(groupId.ToString()).SendAsync("AddCronOccurrenceNotification", json);
         }
 
         public async Task UpdateCronOccurrenceAsync(Guid groupId, object occurrence)
         {
-            await _hubContext.Clients.Group(groupId.ToString()).SendAsync("UpdateCronOccurrenceNotification", occurrence);
+            var json = JsonSerializer.SerializeToElement((CronTickerOccurrenceEntity<CronTickerEntity>)occurrence, DashboardJsonSerializerContext.Default.CronTickerOccurrenceEntityCronTickerEntity);
+            await _hubContext.Clients.Group(groupId.ToString()).SendAsync("UpdateCronOccurrenceNotification", json);
         }
 
         public Task UpdateTimeTickerFromInternalFunctionContext<TTimeTicker>(InternalFunctionContext internalFunctionContext)
@@ -115,20 +128,21 @@ namespace TickerQ.Dashboard.Hubs
         public Task UpdateCronOccurrenceFromInternalFunctionContext<TCronTicker>(InternalFunctionContext internalFunctionContext)
             where TCronTicker : CronTickerEntity, new()
         {
-            var updatePayload = new
+            var updatePayload = new CronOccurrenceUpdateNotification
             {
-                id = internalFunctionContext.TickerId,
-                status = internalFunctionContext.Status,
-                cronTickerId = internalFunctionContext.ParentId,
-                executedAt = internalFunctionContext.ExecutedAt,
-                elapsedTime = internalFunctionContext.ElapsedTime,
-                retryCount = internalFunctionContext.RetryCount,
-                exceptionMessage = internalFunctionContext.ExceptionDetails
+                Id = internalFunctionContext.TickerId,
+                Status = internalFunctionContext.Status,
+                CronTickerId = internalFunctionContext.ParentId,
+                ExecutedAt = internalFunctionContext.ExecutedAt,
+                ElapsedTime = internalFunctionContext.ElapsedTime,
+                RetryCount = internalFunctionContext.RetryCount,
+                ExceptionMessage = internalFunctionContext.ExceptionDetails
             };
 
+            var json = JsonSerializer.SerializeToElement(updatePayload, DashboardJsonSerializerContext.Default.CronOccurrenceUpdateNotification);
             _ = _hubContext.Clients
                 .Group(internalFunctionContext.ParentId?.ToString() ?? string.Empty)
-                .SendAsync("UpdateCronOccurrenceNotification", updatePayload);
+                .SendAsync("UpdateCronOccurrenceNotification", json);
 
             return Task.CompletedTask;
         }

--- a/src/TickerQ.Dashboard/Infrastructure/DashboardJsonSerializerContext.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/DashboardJsonSerializerContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using TickerQ.Dashboard.Hubs;
 using TickerQ.Utilities.DashboardDtos;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Entities.BaseEntity;
@@ -38,6 +39,8 @@ namespace TickerQ.Dashboard.Infrastructure;
 [JsonSerializable(typeof(CronOccurrenceTickerGraphData))]
 [JsonSerializable(typeof(CronOccurrenceTickerGraphData[]))]
 [JsonSerializable(typeof(IList<CronOccurrenceTickerGraphData>))]
+// Hub notification DTOs
+[JsonSerializable(typeof(CronOccurrenceUpdateNotification))]
 // Entity types (base classes for serialization)
 [JsonSerializable(typeof(BaseTickerEntity))]
 [JsonSerializable(typeof(TimeTickerEntity))]

--- a/src/TickerQ.Utilities/Interfaces/ITickerQNotificationHubSender.cs
+++ b/src/TickerQ.Utilities/Interfaces/ITickerQNotificationHubSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Models;
@@ -15,11 +16,11 @@ namespace TickerQ.Utilities.Interfaces
         Task AddTimeTickersBatchNotifyAsync();
         Task UpdateTimeTickerNotifyAsync(object timeTicker);
         Task RemoveTimeTickerNotifyAsync(Guid id);
-        void UpdateActiveThreads(object activeThreads);
-        void UpdateNextOccurrence(object nextOccurrence);
-        void UpdateHostStatus(object active);
-        void UpdateHostException(object exceptionMessage);
-        Task UpdateNodeHeartBeatAsync(object nodeHeartBeat);
+        void UpdateActiveThreads(string activeThreads);
+        void UpdateNextOccurrence(DateTime? nextOccurrence);
+        void UpdateHostStatus(bool active);
+        void UpdateHostException(string exceptionMessage);
+        Task UpdateNodeHeartBeatAsync(JsonElement nodeHeartBeat);
         Task AddCronOccurrenceAsync(Guid groupId, object occurrence);
         Task UpdateCronOccurrenceAsync(Guid groupId, object occurrence);
         Task UpdateTimeTickerFromInternalFunctionContext<TTimeTickerEntity>(InternalFunctionContext internalFunctionContext) where TTimeTickerEntity : TimeTickerEntity<TTimeTickerEntity>, new();

--- a/src/TickerQ.Utilities/Temps/NoOpTickerQNotificationHubSender.cs
+++ b/src/TickerQ.Utilities/Temps/NoOpTickerQNotificationHubSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Interfaces;
@@ -44,23 +45,23 @@ namespace TickerQ.Utilities.Temps
             return Task.CompletedTask;
         }
 
-        public void UpdateActiveThreads(object activeThreads)
+        public void UpdateActiveThreads(string activeThreads)
         {
         }
 
-        public void UpdateNextOccurrence(object nextOccurrence)
+        public void UpdateNextOccurrence(DateTime? nextOccurrence)
         {
         }
 
-        public void UpdateHostStatus(object active)
+        public void UpdateHostStatus(bool active)
         {
         }
 
-        public void UpdateHostException(object exceptionMessage)
+        public void UpdateHostException(string exceptionMessage)
         {
         }
 
-        public Task UpdateNodeHeartBeatAsync(object nodeHeartBeat)
+        public Task UpdateNodeHeartBeatAsync(JsonElement nodeHeartBeat)
         {
             return Task.CompletedTask;
         }

--- a/src/TickerQ.Utilities/TickerQ.Utilities.csproj
+++ b/src/TickerQ.Utilities/TickerQ.Utilities.csproj
@@ -9,6 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>TickerQ.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
 	</ItemGroup>
 

--- a/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
+++ b/src/TickerQ/DependencyInjection/TickerQServiceExtensions.cs
@@ -135,15 +135,15 @@ namespace TickerQ.DependencyInjection
                 {
                     if (type == CoreNotifyActionType.NotifyHostExceptionMessage)
                     {
-                        notificationHubSender.UpdateHostException(value);
+                        notificationHubSender.UpdateHostException((string)value);
                         tickerExecutionContext.LastHostExceptionMessage = (string)value;
                     }
                     else if (type == CoreNotifyActionType.NotifyNextOccurence)
-                        notificationHubSender.UpdateNextOccurrence(value);
+                        notificationHubSender.UpdateNextOccurrence(value is DateTime dt ? (DateTime?)dt : null);
                     else if (type == CoreNotifyActionType.NotifyHostStatus)
-                        notificationHubSender.UpdateHostStatus(value);
+                        notificationHubSender.UpdateHostStatus(value is bool b && b);
                     else if (type == CoreNotifyActionType.NotifyThreadCount)
-                        notificationHubSender.UpdateActiveThreads(value);
+                        notificationHubSender.UpdateActiveThreads((string)value);
                 };
             }
             // If background services are not registered (due to DisableBackgroundServices()),

--- a/tests/TickerQ.Tests/SerializerGlobalPollutionTests.cs
+++ b/tests/TickerQ.Tests/SerializerGlobalPollutionTests.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using TickerQ.Dashboard;
+using TickerQ.Dashboard.DependencyInjection;
+using TickerQ.Dashboard.Infrastructure;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.Tests;
+
+public sealed class SerializerGlobalPollutionTests
+{
+    private static (IServiceProvider services, DashboardOptionsBuilder options) BuildServicesWithDashboard(
+        bool registerUserHttpResolver = false,
+        IJsonTypeInfoResolver? userResolver = null)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Test" });
+        if (registerUserHttpResolver && userResolver != null)
+        {
+            builder.Services.ConfigureHttpJsonOptions(opts =>
+                opts.SerializerOptions.TypeInfoResolverChain.Add(userResolver));
+        }
+        var dashboardOptions = new DashboardOptionsBuilder();
+        builder.Services.AddDashboardService<TimeTickerEntity, CronTickerEntity>(dashboardOptions);
+        var sp = builder.Services.BuildServiceProvider();
+        return (sp, dashboardOptions);
+    }
+
+    private static IServiceProvider BuildServicesWithoutDashboard()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Test" });
+        builder.Services.AddSignalR();
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AddDashboardService_ShouldNotPollute_GlobalSignalR_WithDashboardContext()
+    {
+        var (sp, _) = BuildServicesWithDashboard();
+        var hubProtocolOptions = sp.GetRequiredService<IOptions<JsonHubProtocolOptions>>();
+        var chain = hubProtocolOptions.Value.PayloadSerializerOptions.TypeInfoResolverChain;
+
+        Assert.DoesNotContain(chain, resolver => ReferenceEquals(resolver, DashboardJsonSerializerContext.Default));
+    }
+
+    [Fact]
+    public void AddDashboardService_GlobalJsonHubProtocolOptions_ShouldNotContainDashboardContext()
+    {
+        var (sp, _) = BuildServicesWithDashboard();
+        var hubProtocolOptions = sp.GetRequiredService<IOptions<JsonHubProtocolOptions>>();
+        var chain = hubProtocolOptions.Value.PayloadSerializerOptions.TypeInfoResolverChain;
+
+        Assert.DoesNotContain(chain, r => ReferenceEquals(r, DashboardJsonSerializerContext.Default));
+    }
+
+    [Fact]
+    public void AddDashboardService_HttpJsonOptions_ShouldNotInsertResolverAtPositionZero()
+    {
+        var (sp, _) = BuildServicesWithDashboard();
+        var httpJsonOptions = sp.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>();
+        var chain = httpJsonOptions.Value.SerializerOptions.TypeInfoResolverChain;
+
+        Assert.False(
+            chain.Count > 0 && ReferenceEquals(chain[0], DashboardJsonSerializerContext.Default),
+            "DashboardJsonSerializerContext.Default should NOT be at position 0 of TypeInfoResolverChain");
+    }
+
+    [Fact]
+    public void AddDashboardService_HttpJsonOptions_UserResolverIsPreserved()
+    {
+        var userResolver = new DefaultJsonTypeInfoResolver();
+        var (sp, _) = BuildServicesWithDashboard(registerUserHttpResolver: true, userResolver: userResolver);
+        var httpJsonOptions = sp.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>();
+        var chain = httpJsonOptions.Value.SerializerOptions.TypeInfoResolverChain;
+
+        Assert.Contains(chain, r => ReferenceEquals(r, userResolver));
+        Assert.DoesNotContain(chain, r => ReferenceEquals(r, DashboardJsonSerializerContext.Default));
+    }
+
+    [Fact]
+    public void WithoutAddDashboardService_GlobalJsonHubProtocolOptions_DoesNotContainDashboardContext()
+    {
+        // Control test — verifies baseline: no dashboard context without AddDashboardService.
+        var sp = BuildServicesWithoutDashboard();
+        var hubProtocolOptions = sp.GetRequiredService<IOptions<JsonHubProtocolOptions>>();
+        var chain = hubProtocolOptions.Value.PayloadSerializerOptions.TypeInfoResolverChain;
+
+        Assert.DoesNotContain(chain, r => ReferenceEquals(r, DashboardJsonSerializerContext.Default));
+    }
+
+    [Fact]
+    public void DashboardJsonOptions_CanSerialize_CronTickerEntity()
+    {
+        var (_, dashboardOptions) = BuildServicesWithDashboard();
+        Assert.NotNull(dashboardOptions.DashboardJsonOptions);
+
+        var entity = new CronTickerEntity
+        {
+            Id = Guid.NewGuid(),
+            Expression = "* * * * *"
+        };
+
+        var json = JsonSerializer.Serialize(
+            entity,
+            dashboardOptions.DashboardJsonOptions.GetTypeInfo(typeof(CronTickerEntity)));
+
+        Assert.False(string.IsNullOrEmpty(json));
+        Assert.Contains("\"expression\"", json);
+    }
+
+    [Fact]
+    public void DashboardJsonOptions_CanSerialize_TimeTickerEntity()
+    {
+        var (_, dashboardOptions) = BuildServicesWithDashboard();
+        Assert.NotNull(dashboardOptions.DashboardJsonOptions);
+
+        var entity = new TimeTickerEntity
+        {
+            Id = Guid.NewGuid()
+        };
+
+        var json = JsonSerializer.Serialize(
+            entity,
+            dashboardOptions.DashboardJsonOptions.GetTypeInfo(typeof(TimeTickerEntity)));
+
+        Assert.False(string.IsNullOrEmpty(json));
+        Assert.Contains("\"id\"", json);
+    }
+
+    [Fact]
+    public void DashboardJsonOptions_CamelCase_NamingPolicy_IsApplied()
+    {
+        var (_, dashboardOptions) = BuildServicesWithDashboard();
+
+        var entity = new CronTickerEntity
+        {
+            Id = Guid.NewGuid(),
+            Expression = "0 * * * *"
+        };
+
+        var json = JsonSerializer.Serialize(
+            entity,
+            dashboardOptions.DashboardJsonOptions.GetTypeInfo(typeof(CronTickerEntity)));
+
+        Assert.DoesNotContain("\"Expression\"", json);
+        Assert.Contains("\"expression\"", json);
+    }
+
+    [Fact]
+    public void DashboardJsonOptions_CanSerialize_PaginationResult()
+    {
+        var (_, dashboardOptions) = BuildServicesWithDashboard();
+        Assert.NotNull(dashboardOptions.DashboardJsonOptions);
+
+        var result = new PaginationResult<CronTickerEntity>(
+            new[]
+            {
+                new CronTickerEntity { Id = Guid.NewGuid(), Expression = "* * * * *" },
+                new CronTickerEntity { Id = Guid.NewGuid(), Expression = "0 0 * * *" }
+            },
+            totalCount: 2,
+            pageNumber: 1,
+            pageSize: 10);
+
+        var json = JsonSerializer.Serialize(
+            result,
+            dashboardOptions.DashboardJsonOptions.GetTypeInfo(typeof(PaginationResult<CronTickerEntity>)));
+
+        Assert.False(string.IsNullOrEmpty(json));
+        Assert.Contains("\"items\"", json);
+        Assert.Contains("\"totalCount\"", json);
+    }
+
+    [Fact]
+    public void DashboardJsonOptions_CanSerialize_Guid_AndEnum()
+    {
+        var (_, dashboardOptions) = BuildServicesWithDashboard();
+        Assert.NotNull(dashboardOptions.DashboardJsonOptions);
+
+        var id = Guid.NewGuid();
+        var guidJson = JsonSerializer.Serialize(
+            id,
+            dashboardOptions.DashboardJsonOptions.GetTypeInfo(typeof(Guid)));
+        Assert.False(string.IsNullOrEmpty(guidJson));
+
+        // Roundtrip: deserialize back and verify equality.
+        var roundtripped = JsonSerializer.Deserialize<Guid>(guidJson);
+        Assert.Equal(id, roundtripped);
+
+        // Enum serialization — TickerStatus.Done
+        var status = TickerStatus.Done;
+        var statusJson = JsonSerializer.Serialize(
+            status,
+            dashboardOptions.DashboardJsonOptions.GetTypeInfo(typeof(TickerStatus)));
+        Assert.False(string.IsNullOrEmpty(statusJson));
+    }
+
+    [Fact]
+    public void DashboardJsonOptions_IsIsolated_FromGlobalHttpJsonOptions()
+    {
+        var (sp, dashboardOptions) = BuildServicesWithDashboard();
+
+        var globalHttpJsonOptions = sp
+            .GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>()
+            .Value
+            .SerializerOptions;
+
+        Assert.NotNull(dashboardOptions.DashboardJsonOptions);
+        Assert.NotSame(globalHttpJsonOptions, dashboardOptions.DashboardJsonOptions);
+    }
+}

--- a/tests/TickerQ.Tests/TickerQ.Tests.csproj
+++ b/tests/TickerQ.Tests/TickerQ.Tests.csproj
@@ -7,6 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.4" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(DotNetVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -21,6 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\TickerQ.Caching.StackExchangeRedis\TickerQ.Caching.StackExchangeRedis.csproj" />
       <ProjectReference Include="..\..\src\TickerQ.Dashboard\TickerQ.Dashboard.csproj" />
       <ProjectReference Include="..\..\src\TickerQ.Utilities\TickerQ.Utilities.csproj" />
       <ProjectReference Include="..\..\src\TickerQ\TickerQ.csproj" />

--- a/tests/TickerQ.Tests/TrimSafeSerializationTests.cs
+++ b/tests/TickerQ.Tests/TrimSafeSerializationTests.cs
@@ -1,0 +1,248 @@
+using System.Text.Json;
+using TickerQ.Caching.StackExchangeRedis;
+using TickerQ.Dashboard.Infrastructure;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Interfaces;
+
+namespace TickerQ.Tests;
+
+public sealed class TrimSafeSerializationTests
+{
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_String()
+    {
+        Assert.NotNull(DashboardJsonSerializerContext.Default.String);
+    }
+
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_NullableDateTime()
+    {
+        Assert.NotNull(DashboardJsonSerializerContext.Default.NullableDateTime);
+    }
+
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_Boolean()
+    {
+        Assert.NotNull(DashboardJsonSerializerContext.Default.Boolean);
+    }
+
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_CronTickerEntity()
+    {
+        Assert.NotNull(DashboardJsonSerializerContext.Default.CronTickerEntity);
+    }
+
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_TimeTickerEntity()
+    {
+        Assert.NotNull(DashboardJsonSerializerContext.Default.TimeTickerEntity);
+    }
+
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_CronTickerOccurrenceEntityCronTickerEntity()
+    {
+        // Property name for CronTickerOccurrenceEntity<CronTickerEntity> as emitted by the source generator.
+        Assert.NotNull(DashboardJsonSerializerContext.Default.CronTickerOccurrenceEntityCronTickerEntity);
+    }
+
+    [Fact]
+    public void DashboardContext_HasTypeInfo_For_CronOccurrenceUpdateNotification()
+    {
+        Assert.NotNull(DashboardJsonSerializerContext.Default.CronOccurrenceUpdateNotification);
+    }
+
+    [Fact]
+    public void SerializeToElement_String_ProducesCorrectJson()
+    {
+        var element = JsonSerializer.SerializeToElement("hello", DashboardJsonSerializerContext.Default.String);
+
+        Assert.Equal(JsonValueKind.String, element.ValueKind);
+        Assert.Equal("hello", element.GetString());
+    }
+
+    [Fact]
+    public void SerializeToElement_NullableDateTime_WithValue_ProducesCorrectJson()
+    {
+        DateTime? value = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var element = JsonSerializer.SerializeToElement(value, DashboardJsonSerializerContext.Default.NullableDateTime);
+
+        Assert.Equal(JsonValueKind.String, element.ValueKind);
+        Assert.False(string.IsNullOrEmpty(element.GetString()));
+    }
+
+    [Fact]
+    public void SerializeToElement_NullableDateTime_Null_ProducesJsonNull()
+    {
+        DateTime? value = null;
+
+        var element = JsonSerializer.SerializeToElement(value, DashboardJsonSerializerContext.Default.NullableDateTime);
+
+        Assert.Equal(JsonValueKind.Null, element.ValueKind);
+    }
+
+    [Fact]
+    public void SerializeToElement_CronTickerEntity_ProducesExpectedProperties()
+    {
+        var id = Guid.NewGuid();
+        var entity = new CronTickerEntity
+        {
+            Id = id,
+            Expression = "0 * * * *",
+            IsEnabled = true,
+            Retries = 3
+        };
+
+        var element = JsonSerializer.SerializeToElement(entity, DashboardJsonSerializerContext.Default.CronTickerEntity);
+
+        Assert.Equal(JsonValueKind.Object, element.ValueKind);
+
+        Assert.True(element.TryGetProperty("id", out var idProp));
+        Assert.Equal(id.ToString(), idProp.GetString());
+
+        Assert.True(element.TryGetProperty("expression", out var exprProp));
+        Assert.Equal("0 * * * *", exprProp.GetString());
+
+        Assert.True(element.TryGetProperty("isEnabled", out var enabledProp));
+        Assert.True(enabledProp.GetBoolean());
+
+        Assert.True(element.TryGetProperty("retries", out var retriesProp));
+        Assert.Equal(3, retriesProp.GetInt32());
+    }
+
+    [Fact]
+    public void SerializeToElement_CronOccurrenceUpdateNotification_ProducesAllSevenProperties()
+    {
+        var id = Guid.NewGuid();
+        var cronTickerId = Guid.NewGuid();
+        var executedAt = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var dto = new TickerQ.Dashboard.Hubs.CronOccurrenceUpdateNotification
+        {
+            Id = id,
+            Status = TickerStatus.Done,
+            CronTickerId = cronTickerId,
+            ExecutedAt = executedAt,
+            ElapsedTime = 1500L,
+            RetryCount = 1,
+            ExceptionMessage = "test-error"
+        };
+
+        var element = JsonSerializer.SerializeToElement(dto, DashboardJsonSerializerContext.Default.CronOccurrenceUpdateNotification);
+
+        Assert.Equal(JsonValueKind.Object, element.ValueKind);
+
+        Assert.True(element.TryGetProperty("id", out var idProp));
+        Assert.Equal(id.ToString(), idProp.GetString());
+
+        Assert.True(element.TryGetProperty("status", out _));
+        Assert.True(element.TryGetProperty("cronTickerId", out var cronIdProp));
+        Assert.Equal(cronTickerId.ToString(), cronIdProp.GetString());
+
+        Assert.True(element.TryGetProperty("executedAt", out _));
+
+        Assert.True(element.TryGetProperty("elapsedTime", out var elapsedProp));
+        Assert.Equal(1500L, elapsedProp.GetInt64());
+
+        Assert.True(element.TryGetProperty("retryCount", out var retryProp));
+        Assert.Equal(1, retryProp.GetInt32());
+
+        Assert.True(element.TryGetProperty("exceptionMessage", out var exMsgProp));
+        Assert.Equal("test-error", exMsgProp.GetString());
+    }
+
+    [Fact]
+    public void CronOccurrenceUpdateNotification_HasExpectedPropertyNames()
+    {
+        var type = typeof(TickerQ.Dashboard.Hubs.CronOccurrenceUpdateNotification);
+
+        Assert.NotNull(type.GetProperty("Id"));
+        Assert.NotNull(type.GetProperty("Status"));
+        Assert.NotNull(type.GetProperty("CronTickerId"));
+        Assert.NotNull(type.GetProperty("ExecutedAt"));
+        Assert.NotNull(type.GetProperty("ElapsedTime"));
+        Assert.NotNull(type.GetProperty("RetryCount"));
+        Assert.NotNull(type.GetProperty("ExceptionMessage"));
+    }
+
+    [Fact]
+    public void CronOccurrenceUpdateNotification_SerializesWithCamelCaseNames()
+    {
+        // The JSON keys must be camelCase to match the anonymous type they replace.
+        var dto = new TickerQ.Dashboard.Hubs.CronOccurrenceUpdateNotification
+        {
+            Id = Guid.NewGuid(),
+            Status = TickerStatus.Idle,
+            CronTickerId = Guid.NewGuid(),
+            ExecutedAt = DateTime.UtcNow,
+            ElapsedTime = 100L,
+            RetryCount = 0,
+            ExceptionMessage = null
+        };
+
+        var element = JsonSerializer.SerializeToElement(dto, DashboardJsonSerializerContext.Default.CronOccurrenceUpdateNotification);
+        var json = element.GetRawText();
+
+        Assert.Contains("\"id\"", json);
+        Assert.Contains("\"status\"", json);
+        Assert.Contains("\"cronTickerId\"", json);
+        Assert.Contains("\"executedAt\"", json);
+        Assert.Contains("\"elapsedTime\"", json);
+        Assert.Contains("\"retryCount\"", json);
+
+        // Assert no PascalCase keys leaked through
+        Assert.DoesNotContain("\"Id\"", json);
+        Assert.DoesNotContain("\"Status\"", json);
+        Assert.DoesNotContain("\"CronTickerId\"", json);
+        Assert.DoesNotContain("\"ElapsedTime\"", json);
+    }
+
+    [Fact]
+    public void UpdateNodeHeartBeatAsync_AcceptsJsonElement()
+    {
+        var method = typeof(ITickerQNotificationHubSender).GetMethod("UpdateNodeHeartBeatAsync");
+
+        Assert.NotNull(method);
+
+        var parameters = method!.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(typeof(JsonElement), parameters[0].ParameterType);
+    }
+
+    [Fact]
+    public void UpdateHostStatus_AcceptsBool()
+    {
+        var method = typeof(ITickerQNotificationHubSender).GetMethod("UpdateHostStatus");
+
+        Assert.NotNull(method);
+
+        var parameters = method!.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(typeof(bool), parameters[0].ParameterType);
+    }
+
+    [Fact]
+    public void RedisContext_HasTypeInfo_For_ICollectionTimeTickerEntity()
+    {
+        var typeInfo = RedisContextJsonSerializerContext.Default.Options.GetTypeInfo(typeof(ICollection<TimeTickerEntity>));
+        Assert.NotNull(typeInfo);
+    }
+
+    [Fact]
+    public void TimeTickerEntity_WithChildren_RoundTripsViaRedisContext()
+    {
+        // Verifies that a TimeTickerEntity with a populated Children collection survives a full
+        // serialize→deserialize round-trip using the RedisContextJsonSerializerContext.
+        var parent = new TimeTickerEntity { Id = Guid.NewGuid() };
+        var child = new TimeTickerEntity { Id = Guid.NewGuid() };
+        parent.Children = new List<TimeTickerEntity> { child };
+
+        var json = JsonSerializer.Serialize(parent, RedisContextJsonSerializerContext.Default.TimeTickerEntity);
+        var deserialized = JsonSerializer.Deserialize(json, RedisContextJsonSerializerContext.Default.TimeTickerEntity);
+
+        Assert.NotNull(deserialized);
+        Assert.Single(deserialized.Children);
+        Assert.Equal(child.Id, deserialized.Children.First().Id);
+    }
+}


### PR DESCRIPTION
- Use source-generated JsonSerializerContext for all SignalR hub notifications, enforcing camelCase and AOT safety
- Update ITickerQNotificationHubSender and implementations to use strongly-typed parameters (string, bool, DateTime?, JsonElement)
- Add CronOccurrenceUpdateNotification DTO and register for source generation
- Extend DashboardJsonSerializerContext and RedisContextJsonSerializerContext to cover all required types and collections
- Prevent AddDashboardService from polluting global SignalR/HTTP JSON options
- Add SerializerGlobalPollutionTests and TrimSafeSerializationTests to verify isolation, camelCase output, and round-trip serialization
- Update project files to expose internals to test assemblies and ensure all dependencies are referenced

Fixes #836 #830 #829 and maybe more similar reports