### PR TITLE
Fix ScheduledFor for recovered cron occurrences

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
@@ -60,6 +60,7 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                 Id = e.Id,
                 UpdatedAt = e.UpdatedAt,
                 CronTickerId = e.CronTickerId,
+                ExecutionTime = e.ExecutionTime,
                 CronTicker = new TCronTicker
                 {
                     Id = e.CronTicker.Id,

--- a/tests/TickerQ.EntityFrameworkCore.Tests/Infrastructure/EfCorePersistenceProviderTests.cs
+++ b/tests/TickerQ.EntityFrameworkCore.Tests/Infrastructure/EfCorePersistenceProviderTests.cs
@@ -802,6 +802,7 @@ public class EfCorePersistenceProviderTests : IAsyncLifetime
 
         Assert.Single(results);
         Assert.Equal(occ.Id, results[0].Id);
+        Assert.Equal(oldTime, results[0].ExecutionTime);
 
         // Verify DB
         using var ctx = CreateVerifyContext();


### PR DESCRIPTION
## Summary

Fixes an EF Core recovery-path bug where overdue cron occurrences returned by `QueueTimedOutCronTickerOccurrences` did not include `ExecutionTime` in the projection.

Because `ExecutionTime` was not projected, `InternalFunctionContext.ExecutionTime` stayed at `default(DateTime)`, which then surfaced to handlers as an invalid `TickerFunctionContext.ScheduledFor` value.

This change includes `ExecutionTime` in the EF Core timed-out cron occurrence projection and adds regression coverage to ensure recovered occurrences preserve the persisted `ExecutionTime`.

Fixes #832

## Test plan

- Added EF Core provider regression assertion for `QueueTimedOutCronTickerOccurrences`.
- Verified `TickerQ.EntityFrameworkCore` builds successfully.