### PR TITLE
security: run 'npm ci' rather than 'npm install' in ci/cd workflows #853

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: '20'
 
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
         working-directory: src/TickerQ.Dashboard/wwwroot
 
       - name: Build frontend

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,7 @@ jobs:
           node-version: "20"
 
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
         working-directory: src/TickerQ.Dashboard/wwwroot
 
       - name: Build frontend


### PR DESCRIPTION
#853