### PR TITLE
Customized dashboard buttons

### DIFF
--- a/src/TickerQ.Dashboard/DashboardHeaderButton.cs
+++ b/src/TickerQ.Dashboard/DashboardHeaderButton.cs
@@ -1,0 +1,11 @@
+namespace TickerQ.Dashboard;
+
+/// <summary>Defines a custom button rendered in the TickerQ dashboard header.</summary>
+public sealed class DashboardHeaderButton
+{
+    public string? Label { get; set; }
+    public string? Icon { get; set; }
+    public string? Href { get; set; }
+    public bool OpenInNewTab { get; set; }
+    public string? Tooltip { get; set; }
+}

--- a/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
+++ b/src/TickerQ.Dashboard/DashboardOptionsBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
@@ -23,6 +24,8 @@ public class DashboardOptionsBuilder
     public Action<IApplicationBuilder> PostDashboardMiddleware { get; set; }
     
     internal JsonSerializerOptions DashboardJsonOptions { get; set; }
+
+    internal List<DashboardHeaderButton> HeaderButtons { get; } = new();
 
     /// <summary>Tracks whether dashboard middleware has been applied to prevent double registration.</summary>
     internal bool MiddlewareApplied { get; set; }
@@ -87,6 +90,43 @@ public class DashboardOptionsBuilder
         return this;
     }
     
+    /// <summary>Add a custom button to the dashboard header</summary>
+    public DashboardOptionsBuilder AddHeaderButton(Action<DashboardHeaderButton> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var button = new DashboardHeaderButton();
+        configure(button);
+
+        if (string.IsNullOrWhiteSpace(button.Label))
+            throw new ArgumentException("Header button must have a non-empty Label.", nameof(configure));
+
+        if (string.IsNullOrWhiteSpace(button.Href))
+            throw new ArgumentException("Header button must have a non-empty Href.", nameof(configure));
+
+        if (button.Href.StartsWith("//"))
+            throw new ArgumentException(
+                $"Header button '{button.Label}' uses a protocol-relative URL which is not allowed. Use an explicit https:// URL or a root-relative path.",
+                nameof(configure));
+
+        if (Uri.TryCreate(button.Href, UriKind.Absolute, out var uri))
+        {
+            if (uri.Scheme is not ("http" or "https" or "mailto" or "tel"))
+                throw new ArgumentException(
+                    $"Header button '{button.Label}' has an unsafe URL scheme '{uri.Scheme}'. Allowed schemes: http, https, mailto, tel, or a relative path starting with '/' or './'.",
+                    nameof(configure));
+        }
+        else if (!button.Href.StartsWith('/') && !button.Href.StartsWith("./"))
+        {
+            throw new ArgumentException(
+                $"Header button '{button.Label}' has an invalid relative URL. Relative paths must start with '/' or './'.",
+                nameof(configure));
+        }
+
+        HeaderButtons.Add(button);
+        return this;
+    }
+
     /// <summary>Validate the authentication configuration</summary>
     internal void Validate()
     {

--- a/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/TickerQ.Dashboard/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Builder;
@@ -214,7 +215,17 @@ namespace TickerQ.Dashboard.DependencyInjection
                     Mode = config.Auth.Mode.ToString().ToLower(),
                     Enabled = config.Auth.IsEnabled,
                     SessionTimeout = config.Auth.SessionTimeoutMinutes
-                }
+                },
+                HeaderButtons = config.HeaderButtons
+                    .Select(b => new HeaderButtonResponse
+                    {
+                        Label = b.Label,
+                        Icon = b.Icon,
+                        Href = b.Href,
+                        OpenInNewTab = b.OpenInNewTab,
+                        Tooltip = b.Tooltip
+                    })
+                    .ToArray()
             };
 
             var frontendJsonOptions = new JsonSerializerOptions

--- a/src/TickerQ.Dashboard/Infrastructure/DashboardJsonSerializerContext.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/DashboardJsonSerializerContext.cs
@@ -25,6 +25,8 @@ namespace TickerQ.Dashboard.Infrastructure;
 [JsonSerializable(typeof(NextTickerResponse))]
 [JsonSerializable(typeof(HostStatusResponse))]
 [JsonSerializable(typeof(FrontendConfigResponse))]
+[JsonSerializable(typeof(HeaderButtonResponse))]
+[JsonSerializable(typeof(HeaderButtonResponse[]))]
 // Tuple responses for statistics
 [JsonSerializable(typeof(TupleResponse<int, int>))]
 [JsonSerializable(typeof(TupleResponse<int, int>[]))]

--- a/src/TickerQ.Dashboard/Infrastructure/DashboardResponses.cs
+++ b/src/TickerQ.Dashboard/Infrastructure/DashboardResponses.cs
@@ -74,4 +74,14 @@ internal class FrontendConfigResponse
     public string BasePath { get; set; }
     public string BackendDomain { get; set; }
     public AuthInfoResponse Auth { get; set; }
+    public HeaderButtonResponse[] HeaderButtons { get; set; } = [];
+}
+
+internal class HeaderButtonResponse
+{
+    public required string Label { get; set; }
+    public string? Icon { get; set; }
+    public required string Href { get; set; }
+    public bool OpenInNewTab { get; set; }
+    public string? Tooltip { get; set; }
 }

--- a/src/TickerQ.Dashboard/wwwroot/src/components/layout/DashboardLayout.vue
+++ b/src/TickerQ.Dashboard/wwwroot/src/components/layout/DashboardLayout.vue
@@ -15,6 +15,9 @@ const navigationLinks = [
   { icon: 'mdi-calendar-sync', text: 'Cron Tickers', path: '/cron-tickers' },
 ]
 
+const customHeaderButtons = ref(window.TickerQConfig?.headerButtons ?? [])
+const singleHeaderButton = computed(() => customHeaderButtons.value[0])
+
 // Reactive state
 const tickerHostStatus = ref(false)
 const currentMachine = ref('Loading...')
@@ -141,6 +144,8 @@ const loadInitialData = async () => {
 
 // Initialize connection on mount
 onMounted(async () => {
+  customHeaderButtons.value = window.TickerQConfig?.headerButtons ?? []
+
   // Wait for next tick to ensure Pinia stores are fully initialized
   await nextTick()
 
@@ -355,30 +360,82 @@ const handleForceUIUpdate = () => {
             <div class="header-divider"></div>
           </div>
 
-          <div class="header-right">
-            <div class="navigation-links">
-              <v-btn
-                v-for="link in navigationLinks"
-                :key="link.path"
-                :text="link.text"
-                :to="link.path"
-                variant="text"
-                class="nav-link"
-                :prepend-icon="link.icon"
-              ></v-btn>
-            </div>
+            <div class="header-right">
+              <div class="navigation-links">
+                <v-btn
+                  v-for="link in navigationLinks"
+                  :key="link.path"
+                  :text="link.text"
+                  :to="link.path"
+                  variant="text"
+                  class="nav-link"
+                  :prepend-icon="link.icon"
+                ></v-btn>
+              </div>
 
-            <!-- Auth Header Component -->
-            <div class="auth-container">
-              <AuthHeader
-                :show-login-form="true"
-                :show-user-info="true"
-                :show-logout="true"
-                @login="handleAuthLogin"
-                @logout="handleAuthLogout"
-              />
+              <!-- Custom header buttons -->
+              <div v-if="customHeaderButtons.length > 0" class="custom-header-buttons">
+
+                <template v-if="customHeaderButtons.length === 1">
+                  <v-tooltip :text="singleHeaderButton.tooltip" :disabled="!singleHeaderButton.tooltip" location="bottom">
+                    <template #activator="{ props: tooltipProps }">
+                      <v-btn
+                        v-bind="tooltipProps"
+                        :href="singleHeaderButton.href"
+                        :target="singleHeaderButton.openInNewTab ? '_blank' : '_self'"
+                        :rel="singleHeaderButton.openInNewTab ? 'noopener noreferrer' : undefined"
+                        :prepend-icon="singleHeaderButton.icon"
+                        variant="text"
+                        size="small"
+                        class="nav-link custom-header-btn"
+                      >{{ singleHeaderButton.label }}</v-btn>
+                    </template>
+                  </v-tooltip>
+                </template>
+
+                <!-- Multiple buttons: dropdown menu -->
+                <v-menu v-else location="bottom end" :close-on-content-click="true">
+                  <template #activator="{ props: menuProps }">
+                    <v-tooltip text="More links" location="bottom">
+                      <template #activator="{ props: tooltipProps }">
+                        <v-btn
+                          v-bind="{ ...menuProps, ...tooltipProps }"
+                          icon="mdi-dots-horizontal"
+                          variant="text"
+                          size="small"
+                          class="nav-link custom-header-menu-btn"
+                          aria-label="More links"
+                        />
+                      </template>
+                    </v-tooltip>
+                  </template>
+                  <v-list density="compact" nav>
+                    <v-list-item
+                      v-for="(btn, index) in customHeaderButtons"
+                      :key="`${btn.href}|${btn.label}|${index}`"
+                      :href="btn.href"
+                      :target="btn.openInNewTab ? '_blank' : '_self'"
+                      :rel="btn.openInNewTab ? 'noopener noreferrer' : undefined"
+                      :prepend-icon="btn.icon"
+                      :title="btn.label"
+                      :subtitle="btn.tooltip || undefined"
+                    />
+                  </v-list>
+                </v-menu>
+
+              </div>
+
+              <!-- Auth Header Component -->
+              <div class="auth-container">
+                <AuthHeader
+                  :show-login-form="true"
+                  :show-user-info="true"
+                  :show-logout="true"
+                  @login="handleAuthLogin"
+                  @logout="handleAuthLogout"
+                />
+              </div>
             </div>
-          </div>
         </div>
       </div>
     </v-app-bar>
@@ -675,6 +732,14 @@ const handleForceUIUpdate = () => {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.custom-header-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-left: 8px;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .nav-link {

--- a/src/TickerQ.Dashboard/wwwroot/src/services/auth.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/services/auth.ts
@@ -13,6 +13,13 @@ declare global {
         enabled: boolean;
         sessionTimeout: number;
       };
+      headerButtons?: Array<{
+        label: string;
+        icon?: string;
+        href: string;
+        openInNewTab?: boolean;
+        tooltip?: string;
+      }>;
     };
   }
 }

--- a/src/TickerQ.Dashboard/wwwroot/src/types/tickerq-config.d.ts
+++ b/src/TickerQ.Dashboard/wwwroot/src/types/tickerq-config.d.ts
@@ -8,6 +8,13 @@ declare global {
         enabled: boolean;
         sessionTimeout: number;
       };
+      headerButtons?: Array<{
+        label: string;
+        icon?: string;
+        href: string;
+        openInNewTab?: boolean;
+        tooltip?: string;
+      }>;
     };
   }
 }

--- a/tests/TickerQ.Tests/DashboardOptionsBuilderTests.cs
+++ b/tests/TickerQ.Tests/DashboardOptionsBuilderTests.cs
@@ -1,0 +1,169 @@
+using System;
+using TickerQ.Dashboard;
+using Xunit;
+
+namespace TickerQ.Tests;
+
+public class DashboardOptionsBuilderTests
+{
+    [Fact]
+    public void AddHeaderButton_NullConfigure_ThrowsArgumentNullException()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.AddHeaderButton(null!));
+    }
+
+    [Fact]
+    public void AddHeaderButton_EmptyLabel_ThrowsArgumentException()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddHeaderButton(b =>
+        {
+            b.Label = "";
+            b.Href = "/dashboard";
+        }));
+    }
+
+    [Fact]
+    public void AddHeaderButton_WhitespaceLabel_ThrowsArgumentException()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddHeaderButton(b =>
+        {
+            b.Label = "   ";
+            b.Href = "/dashboard";
+        }));
+    }
+
+    [Fact]
+    public void AddHeaderButton_EmptyHref_ThrowsArgumentException()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddHeaderButton(b =>
+        {
+            b.Label = "My Link";
+            b.Href = "";
+        }));
+    }
+
+    [Fact]
+    public void AddHeaderButton_ProtocolRelativeUrl_ThrowsArgumentException()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddHeaderButton(b =>
+        {
+            b.Label = "My Link";
+            b.Href = "//example.com";
+        }));
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("JaVaScRiPt:alert(1)")]
+    [InlineData("JAVASCRIPT:alert(1)")]
+    [InlineData("data:text/html,<h1>xss</h1>")]
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData(" javascript:alert(1)")]
+    [InlineData("\njavascript:alert(1)")]
+    [InlineData("\tjavascript:alert(1)")]
+    [InlineData("javascript:alert(1) ")]
+    public void AddHeaderButton_UnsafeScheme_ThrowsArgumentException(string href)
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddHeaderButton(b =>
+        {
+            b.Label = "My Link";
+            b.Href = href;
+        }));
+    }
+
+    [Theory]
+    [InlineData("no-leading-slash")]
+    [InlineData("path/to/page")]
+    [InlineData("%6Aavascript:alert(1)")]
+    [InlineData(" /valid-path")]
+    public void AddHeaderButton_InvalidRelativePath_ThrowsArgumentException(string href)
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        Assert.Throws<ArgumentException>(() => builder.AddHeaderButton(b =>
+        {
+            b.Label = "My Link";
+            b.Href = href;
+        }));
+    }
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com")]
+    [InlineData("mailto:support@example.com")]
+    [InlineData("tel:+15551234567")]
+    [InlineData("/my-dashboard")]
+    [InlineData("./relative-path")]
+    public void AddHeaderButton_ValidHref_AddsButton(string href)
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        builder.AddHeaderButton(b =>
+        {
+            b.Label = "My Link";
+            b.Href = href;
+        });
+
+        var button = Assert.Single(builder.HeaderButtons);
+        Assert.Equal("My Link", button.Label);
+        Assert.Equal(href, button.Href);
+    }
+
+    [Fact]
+    public void AddHeaderButton_SetsButtonProperties()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        builder.AddHeaderButton(b =>
+        {
+            b.Label = "Visit Website";
+            b.Href = "https://example.com";
+            b.Icon = "mdi-web";
+            b.OpenInNewTab = true;
+            b.Tooltip = "Open Website";
+        });
+
+        var button = Assert.Single(builder.HeaderButtons);
+        Assert.Equal("Visit Website", button.Label);
+        Assert.Equal("https://example.com", button.Href);
+        Assert.Equal("mdi-web", button.Icon);
+        Assert.True(button.OpenInNewTab);
+        Assert.Equal("Open Website", button.Tooltip);
+    }
+
+    [Fact]
+    public void AddHeaderButton_MultipleButtons_AllAdded()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        builder
+            .AddHeaderButton(b => { b.Label = "One"; b.Href = "/one"; })
+            .AddHeaderButton(b => { b.Label = "Two"; b.Href = "/two"; })
+            .AddHeaderButton(b => { b.Label = "Three"; b.Href = "/three"; });
+
+        Assert.Equal(3, builder.HeaderButtons.Count);
+    }
+
+    [Fact]
+    public void AddHeaderButton_ReturnsBuilderInstance_ForChaining()
+    {
+        var builder = new DashboardOptionsBuilder();
+
+        var result = builder.AddHeaderButton(b => { b.Label = "Link"; b.Href = "/link"; });
+
+        Assert.Same(builder, result);
+    }
+}


### PR DESCRIPTION
This pull request adds support for configurable custom header buttons in the TickerQ dashboard. It introduces a new API for defining header buttons, validates their configuration for safety, exposes them to the frontend, and updates the dashboard UI to render them. Comprehensive tests are also included to ensure correct behavior and validation.

**Backend changes for custom header buttons:**

* Added the `DashboardHeaderButton` class and a `HeaderButtons` collection to `DashboardOptionsBuilder`, along with an `AddHeaderButton` method to allow configuration of custom header buttons with validation for label, href, and allowed URL schemes. [[1]](diffhunk://#diff-1d0357a548e7295b7ac00322343d9cecddc842bcb216076c138d7e5c6d2fabdeR1-R11) [[2]](diffhunk://#diff-771d1058976d7168f1bc7caf8c444146ec4eb2810089cdafa4e204bd8cf1fa7dR28-R29) [[3]](diffhunk://#diff-771d1058976d7168f1bc7caf8c444146ec4eb2810089cdafa4e204bd8cf1fa7dR93-R129)
* Updated the backend response (`FrontendConfigResponse` and related serialization) to include the configured header buttons, and created a DTO (`HeaderButtonResponse`) for safe transfer to the frontend. [[1]](diffhunk://#diff-7151241ad2b132135478528b51e4ab15916c6a6201e5e2eb370cf682b93bf241R77-R86) [[2]](diffhunk://#diff-b90cf54d59b1702612fcbe401547031f3401a2351cf4bdd2769c83c98cb1a663L217-R228) [[3]](diffhunk://#diff-ad16ea4f5afd6d05acddd054081963b4bb521ab636eab97461b797169f7b9ff9R28-R29)

**Frontend integration and UI updates:**

* Updated the dashboard frontend (`DashboardLayout.vue`) to read and render the custom header buttons: a single button is shown as a standalone button, while multiple buttons are grouped into a dropdown menu with tooltips and icons. [[1]](diffhunk://#diff-58e81e642b7dd459b42e77fb39a0b7e83b4dde77cadc2723febf852b0596b885R18-R20) [[2]](diffhunk://#diff-58e81e642b7dd459b42e77fb39a0b7e83b4dde77cadc2723febf852b0596b885R147-R148) [[3]](diffhunk://#diff-58e81e642b7dd459b42e77fb39a0b7e83b4dde77cadc2723febf852b0596b885R376-R427)
* Added CSS for styling the new header button(s) area in the dashboard.
* Extended TypeScript types to include the new `headerButtons` configuration on the global config object.

**Testing and validation:**

* Added comprehensive unit tests for the `AddHeaderButton` method, covering validation rules, property assignment, and method chaining.

**Example**

```C#
dashboard.AddHeaderButton(b =>
{
    b.Label = "Contact Support";
    b.Href = "mailto:support@companywebsite.com";
    b.Icon = "mdi-email-outline";
    b.Tooltip = "Email Support";
});
dashboard.AddHeaderButton(b =>
{
    b.Label = "Tech Specs";
    b.Href = "https://companywebsite.com/docs/Technical_Specifications.pdf";
    b.Icon = "mdi-file-document-outline";
    b.OpenInNewTab = true;
    b.Tooltip = "View Technical Specifications";
});
```

<img width="687" height="178" alt="image" src="https://github.com/user-attachments/assets/1a9d6c75-e24b-4c2e-b907-b4436f7b929e" />
