### PR TITLE
chore(deps): bump OpenTelemetry.* dependency to CVE patched 1.15.3 version

### DIFF
--- a/src/TickerQ.Instrumentation.OpenTelemetry/README.md
+++ b/src/TickerQ.Instrumentation.OpenTelemetry/README.md
@@ -154,5 +154,5 @@ builder.Logging.AddNLog();
 ## Requirements
 
 - .NET 8.0 or later
-- OpenTelemetry 1.7.0 or later
+- OpenTelemetry 1.15.3 or later
 - TickerQ.Utilities (automatically included)

--- a/src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj
+++ b/src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="[1.7.0,)" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="[1.7.0,)" />
+    <PackageReference Include="OpenTelemetry" Version="[1.15.3,)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="[1.15.3,)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(DotNetAbstractionsVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Package 'OpenTelemetry.Api' 1.7.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-g94r-2vxg-569j
