### PR TITLE
Fix: Avoid InvalidCastException in TickerQHubNotificationSender occurrence serialization

### DIFF
--- a/src/TickerQ.Dashboard/Hubs/TickerQNotificationHubSender.cs
+++ b/src/TickerQ.Dashboard/Hubs/TickerQNotificationHubSender.cs
@@ -16,7 +16,8 @@ namespace TickerQ.Dashboard.Hubs
         private readonly Timer _timeTickerUpdateTimer;
         private int _hasPendingTimeTickerUpdate;
         private static readonly TimeSpan TimeTickerUpdateDebounce = TimeSpan.FromMilliseconds(100);
-        
+        private static readonly JsonSerializerOptions CamelCaseOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
         public TickerQNotificationHubSender(IHubContext<TickerQNotificationHub> hubContext)
         {
             _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
@@ -95,14 +96,21 @@ namespace TickerQ.Dashboard.Hubs
 
         public async Task AddCronOccurrenceAsync(Guid groupId, object occurrence)
         {
-            var json = JsonSerializer.SerializeToElement((CronTickerOccurrenceEntity<CronTickerEntity>)occurrence, DashboardJsonSerializerContext.Default.CronTickerOccurrenceEntityCronTickerEntity);
+            var json = SerializeOccurrence(occurrence);
             await _hubContext.Clients.Group(groupId.ToString()).SendAsync("AddCronOccurrenceNotification", json);
         }
 
         public async Task UpdateCronOccurrenceAsync(Guid groupId, object occurrence)
         {
-            var json = JsonSerializer.SerializeToElement((CronTickerOccurrenceEntity<CronTickerEntity>)occurrence, DashboardJsonSerializerContext.Default.CronTickerOccurrenceEntityCronTickerEntity);
+            var json = SerializeOccurrence(occurrence);
             await _hubContext.Clients.Group(groupId.ToString()).SendAsync("UpdateCronOccurrenceNotification", json);
+        }
+
+        private static JsonElement SerializeOccurrence(object occurrence) 
+        {
+            if (occurrence is CronTickerOccurrenceEntity<CronTickerEntity> typed) 
+                return JsonSerializer.SerializeToElement(typed, DashboardJsonSerializerContext.Default.CronTickerOccurrenceEntityCronTickerEntity); 
+            return JsonSerializer.SerializeToElement(occurrence, CamelCaseOptions);
         }
 
         public Task UpdateTimeTickerFromInternalFunctionContext<TTimeTicker>(InternalFunctionContext internalFunctionContext)


### PR DESCRIPTION
## Related Issue
Fixes #863

`AddCronOccurrenceAsync` and `UpdateCronOccurrenceAsync` previously hard-cast `object occurrence` to `CronTickerOccurrenceEntity<CronTickerEntity>`, throwing `InvalidCastException`
    when a different concrete type was passed
   - Extracted `SerializeOccurrence` helper that attempts a safe `is` cast first; falls back to generic `JsonSerializer.SerializeToElement` with camelCase policy
   - Added static `CamelCaseOptions` field to avoid allocating `JsonSerializerOptions` on every fallback call

   ## Root cause

   Direct cast `(CronTickerOccurrenceEntity<CronTickerEntity>)occurrence` fails at runtime when `occurrence` is a subtype or unrelated type that doesn't satisfy the cast.