### PR TITLE
Move ActivitySource diagnostics into main package

### DIFF
--- a/src/TickerQ.Utilities/Instrumentation/ActivitySourceInstrumentation.cs
+++ b/src/TickerQ.Utilities/Instrumentation/ActivitySourceInstrumentation.cs
@@ -1,0 +1,145 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.Utilities.Instrumentation;
+
+public class ActivitySourceInstrumentation(ILogger<ActivitySourceInstrumentation> logger, SchedulerOptionsBuilder optionsBuilder)
+  : TickerQBaseLoggerInstrumentation(logger, optionsBuilder.NodeIdentifier)
+  , ITickerQInstrumentation
+{
+  private static readonly ActivitySource ActivitySource = new("TickerQ", "1.0.0");
+
+  public override Activity StartJobActivity(string activityName, InternalFunctionContext context)
+  {
+    if (ActivitySource.StartActivity(activityName) is not { } activity)
+      return null;
+
+    activity.SetTag("tickerq.job.id", context.TickerId.ToString());
+    activity.SetTag("tickerq.job.type", context.Type.ToString());
+    activity.SetTag("tickerq.job.function", context.FunctionName);
+    activity.SetTag("tickerq.job.priority", context.CachedPriority.ToString());
+    activity.SetTag("tickerq.job.machine", InstanceIdentifier);
+    activity.SetTag("tickerq.job.retries", context.Retries);
+
+    if (context.ParentId.HasValue)
+      activity.SetTag("tickerq.job.parent_id", context.ParentId.Value.ToString());
+
+    if (context.Type == TickerType.TimeTicker && context.ParentId.HasValue)
+      activity.SetTag("tickerq.job.run_condition", context.RunCondition.ToString());
+
+    return activity;
+  }
+
+  public override void LogJobEnqueued(string jobType, string functionName, Guid jobId, string enqueuedFrom = null)
+  {
+    // Get detailed caller information for OpenTelemetry
+    var callerInfo = string.IsNullOrEmpty(enqueuedFrom) ? CallerInfoHelper.GetCallerInfo(6) : enqueuedFrom;
+    base.LogJobEnqueued(jobType, functionName, jobId, callerInfo);
+
+    using var activity = ActivitySource.StartActivity("tickerq.job.enqueued");
+    if (activity == null) return;
+
+    activity.SetTag("tickerq.job.id", jobId.ToString());
+    activity.SetTag("tickerq.job.type", jobType);
+    activity.SetTag("tickerq.job.function", functionName);
+    activity.SetTag("tickerq.job.enqueued_from", callerInfo);
+  }
+
+  public override void LogJobCompleted(Guid jobId, string functionName, long executionTimeMs, bool success)
+  {
+    base.LogJobCompleted(jobId, functionName, executionTimeMs, success);
+
+    using var activity = ActivitySource.StartActivity("tickerq.job.completed");
+    if (activity == null) return;
+
+    activity.SetStatus(success ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+
+    activity.SetTag("tickerq.job.id", jobId.ToString());
+    activity.SetTag("tickerq.job.function", functionName);
+    activity.SetTag("tickerq.job.execution_time_ms", executionTimeMs);
+    activity.SetTag("tickerq.job.success", success);
+  }
+
+  public override void LogJobFailed(Guid jobId, string functionName, Exception exception, int retryCount)
+  {
+    base.LogJobFailed(jobId, functionName, exception, retryCount);
+
+    using var activity = ActivitySource.StartActivity("tickerq.job.failed");
+    if (activity == null) return;
+
+    activity.SetStatus(ActivityStatusCode.Error, exception.Message);
+
+    activity.SetTag("tickerq.job.id", jobId.ToString());
+    activity.SetTag("tickerq.job.function", functionName);
+    activity.SetTag("tickerq.job.retry_count", retryCount);
+    activity.SetTag("tickerq.job.error_type", exception.GetType().Name);
+    activity.SetTag("tickerq.job.error_message", exception.Message);
+
+    // Record exception information in tags instead of RecordException (not available in all .NET versions)
+    if (exception.StackTrace != null)
+      activity.SetTag("tickerq.job.error_stack_trace", exception.StackTrace);
+  }
+
+  public override void LogJobCancelled(Guid jobId, string functionName, string reason)
+  {
+    base.LogJobCancelled(jobId, functionName, reason);
+
+    using var activity = ActivitySource.StartActivity("tickerq.job.cancelled");
+    if (activity == null) return;
+
+    activity.SetStatus(ActivityStatusCode.Error, reason);
+
+    activity.SetTag("tickerq.job.id", jobId.ToString());
+    activity.SetTag("tickerq.job.function", functionName);
+    activity.SetTag("tickerq.job.cancellation_reason", reason);
+  }
+
+  public override void LogJobSkipped(Guid jobId, string functionName, string reason)
+  {
+    base.LogJobSkipped(jobId, functionName, reason);
+
+    using var activity = ActivitySource.StartActivity("tickerq.job.skipped");
+    if (activity == null) return;
+
+    activity.SetTag("tickerq.job.id", jobId.ToString());
+    activity.SetTag("tickerq.job.function", functionName);
+    activity.SetTag("tickerq.job.skip_reason", reason);
+  }
+
+  public override void LogSeedingDataStarted(string seedingDataType)
+  {
+    base.LogSeedingDataStarted(seedingDataType);
+
+    using var activity = ActivitySource.StartActivity("tickerq.seeding.started");
+    if (activity == null) return;
+
+    activity.SetTag("tickerq.seeding.type", seedingDataType);
+    activity.SetTag("tickerq.seeding.environment", InstanceIdentifier);
+  }
+
+  public override void LogSeedingDataCompleted(string seedingDataType)
+  {
+    base.LogSeedingDataCompleted(seedingDataType);
+
+    using var activity = ActivitySource.StartActivity("tickerq.seeding.completed");
+    if (activity == null) return;
+
+    activity.SetTag("tickerq.seeding.type", seedingDataType);
+    activity.SetTag("tickerq.seeding.environment", InstanceIdentifier);
+  }
+
+  public override void LogRequestDeserializationFailure(string requestType, string functionName, Guid tickerId, TickerType type, Exception exception)
+  {
+    base.LogRequestDeserializationFailure(requestType, functionName, tickerId, type, exception);
+
+    using var activity = ActivitySource.StartActivity("tickerq.job_request_serialization.failed");
+    if (activity == null) return;
+
+    activity.SetTag("tickerq.job.id", tickerId.ToString());
+    activity.SetTag("tickerq.job.function", functionName);
+    activity.SetTag("tickerq.job.cancellation_reason", exception.Message);
+  }
+}

--- a/src/TickerQ.Utilities/Instrumentation/CallerInfoHelper.cs
+++ b/src/TickerQ.Utilities/Instrumentation/CallerInfoHelper.cs
@@ -1,0 +1,101 @@
+﻿using System.Diagnostics;
+using System.IO;
+
+namespace TickerQ.Utilities.Instrumentation;
+
+internal static class CallerInfoHelper
+{
+  /// <summary>
+  /// Gets caller information by analyzing the stack trace
+  /// </summary>
+  /// <param name="skipFrames">Number of frames to skip from the current method</param>
+  /// <returns>Formatted caller information</returns>
+  public static string GetCallerInfo(int skipFrames = 4)
+  {
+    try
+    {
+      var stackTrace = new StackTrace(true);
+      var frame = stackTrace.GetFrame(skipFrames);
+
+      if (frame != null)
+      {
+        var method = DiagnosticMethodInfo.Create(frame);
+        var fileName = frame.GetFileName();
+        var lineNumber = frame.GetFileLineNumber();
+
+        if (method != null)
+        {
+          var className = method.DeclaringTypeName ?? "Unknown";
+          var methodName = method.Name;
+
+          // Filter out compiler-generated methods
+          if (methodName.Contains("<") || methodName.Contains(">"))
+          {
+            // Try to get the next frame for async methods
+            var nextFrame = stackTrace.GetFrame(skipFrames + 1);
+            if (nextFrame != null && DiagnosticMethodInfo.Create(nextFrame) is { } nextMethod)
+            {
+              className = nextMethod.DeclaringTypeName ?? className;
+              methodName = nextMethod.Name;
+              fileName = nextFrame.GetFileName() ?? fileName;
+              lineNumber = nextFrame.GetFileLineNumber();
+            }
+          }
+
+          if (!string.IsNullOrEmpty(fileName))
+          {
+            var shortFileName = Path.GetFileName(fileName);
+            return $"{className}.{methodName} ({shortFileName}:{lineNumber})";
+          }
+
+          return $"{className}.{methodName}";
+        }
+      }
+
+      return "Unknown";
+    }
+    catch
+    {
+      return "Unknown";
+    }
+  }
+
+  /// <summary>
+  /// Gets a simple caller name without file information
+  /// </summary>
+  /// <param name="skipFrames">Number of frames to skip from the current method</param>
+  /// <returns>Simple caller name</returns>
+  public static string GetSimpleCallerInfo(int skipFrames = 4)
+  {
+    try
+    {
+      var stackTrace = new StackTrace(false);
+      var frame = stackTrace.GetFrame(skipFrames);
+
+      if (frame != null && DiagnosticMethodInfo.Create(frame) is { } method)
+      {
+        var className = method.DeclaringTypeName ?? "Unknown";
+        var methodName = method.Name;
+
+        // Filter out compiler-generated methods
+        if (methodName.Contains("<") || methodName.Contains(">"))
+        {
+          var nextFrame = stackTrace.GetFrame(skipFrames + 1);
+          if (nextFrame != null && DiagnosticMethodInfo.Create(nextFrame) is { } nextMethod)
+          {
+            className = nextMethod.DeclaringTypeName ?? className;
+            methodName = nextMethod.Name;
+          }
+        }
+
+        return $"{className}.{methodName}";
+      }
+
+      return "Unknown";
+    }
+    catch
+    {
+      return "Unknown";
+    }
+  }
+}

--- a/src/TickerQ.Utilities/TickerOptionsBuilder.cs
+++ b/src/TickerQ.Utilities/TickerOptionsBuilder.cs
@@ -2,8 +2,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Instrumentation;
 using TickerQ.Utilities.Interfaces;
 using TickerQ.Utilities.Interfaces.Managers;
 
@@ -35,7 +35,7 @@ namespace TickerQ.Utilities
         /// Defaults to true.
         /// </summary>
         internal bool SeedDefinedCronTickers { get; set; } = true;
-        
+
         /// <summary>
         /// Controls whether background services (job processors) should be registered.
         /// Defaults to true. Set to false to only register managers for queuing jobs.
@@ -60,7 +60,7 @@ namespace TickerQ.Utilities
         internal Action<IServiceCollection> ExternalProviderConfigServiceAction { get; set; }
         internal Action<IServiceCollection> DashboardServiceAction { get; set; }
         internal Type TickerExceptionHandlerType { get; private set; }
-        
+
         public TickerOptionsBuilder<TTimeTicker, TCronTicker> ConfigureScheduler(Action<SchedulerOptionsBuilder> schedulerOptionsBuilder)
         {
             schedulerOptionsBuilder?.Invoke(_schedulerOptions);
@@ -77,13 +77,12 @@ namespace TickerQ.Utilities
             set => _schedulerOptions.MinPollingInterval = value;
         }
 
-              
         /// <summary>
         /// JsonSerializerOptions specifically for serializing/deserializing ticker requests.
         /// If not set, default JsonSerializerOptions will be used.
         /// </summary>
         internal JsonSerializerOptions RequestJsonSerializerOptions { get; set; }
-        
+
         /// <summary>
         /// Configures a JsonSerializerContext for AOT-compatible ticker request serialization/deserialization.
         /// Use this when publishing with Native AOT or when trimming is enabled.
@@ -146,15 +145,29 @@ namespace TickerQ.Utilities
             SeedDefinedCronTickers = false;
             return this;
         }
-        
+
         /// <summary>
-        /// Disables background services registration. 
+        /// Disables background services registration.
         /// Use this when you only want to queue jobs without processing them in this application.
         /// Only the managers (ITimeTickerManager, ICronTickerManager) will be available for queuing jobs.
         /// </summary>
         public TickerOptionsBuilder<TTimeTicker, TCronTicker> DisableBackgroundServices()
         {
             RegisterBackgroundServices = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Creates an ActivitySource named "TickerQ" with activity tracing for TickerQ jobs.
+        /// Also includes standard logging through ILogger.
+        /// </summary>
+        public TickerOptionsBuilder<TTimeTicker, TCronTicker> EnableActivitySource()
+        {
+            ExternalProviderConfigServiceAction += services =>
+            {
+              // Replace any existing instrumentation with OpenTelemetry version
+              services.AddSingleton<ITickerQInstrumentation, ActivitySourceInstrumentation>();
+            };
             return this;
         }
 
@@ -203,16 +216,16 @@ namespace TickerQ.Utilities
             UseTickerSeeder(cronSeeder);
             return this;
         }
-        
+
         public TickerOptionsBuilder<TTimeTicker, TCronTicker> SetExceptionHandler<THandler>() where THandler : ITickerExceptionHandler
         {
             TickerExceptionHandlerType = typeof(THandler);
             return this;
         }
-        
+
         internal void UseExternalProviderApplication(Action<IServiceProvider> action)
             => _tickerExecutionContext.ExternalProviderApplicationAction = action;
-        
+
         internal void UseDashboardApplication(Action<object> action)
             => _tickerExecutionContext.DashboardApplicationAction = action;
     }


### PR DESCRIPTION
Fixes: #530

This PR moves what currently is in package `TickerQ.Instrumentation.OpenTelemetry` into `TickerQ.Utilities` (so usable for everyone by just referencing `TickerQ`).

As noted in the issue, the insight is that `TickerQ.Instrumentation.OpenTelemetry` package currently takes a dependency on `OpenTelemetry` but does not use it. It just creates an `ActivitySource` which is a core modern .net concept. **Note that as of today that transitive `OpenTelemetry 1.7.0`  dependency has a moderate vulnerability.** Dependencies are a maintenance burden.

### What changes for users?
The same behavior as before is achieved by referencing only `TickerQ` main package and calling `tickerQBuilder.EnableActivitySource()`.

The method name was changed because it better reflect what it does and leaves the old name `AddOpenTelemetryInstrumentation` available if TickerQ integrates closely with `OpenTelemetry` in the future.

### Code changes
I did minor changes that I will list here, as moved code is hard to compare:
- `CallerInfoHelper` now uses `DiagnosticMethodInfo.Create(frame)` instead of `frame.GetMethod()`.
The latter isn't trimming-friendly.
- Renamed main class to `ActivitySourceInstrumentation`, again to better reflect purpose and leave real "OpenTelemetry" instrumentation available in the future.
- `LogJobEnqueued` was logging directly instead of calling base class like all other methods.
This has been unified and so the `_logger` was useless and has been removed.
- `EnableActivitySource()` has been renamed and is not an extension anymore (directly on `TickerOptionsBuilder`).

### What about old package TickerQ.Instrumentation.OpenTelemetry?
It's still there unchanged, for current users.

It does not provide anything extra compared to main package, and takes an extra useless dependency on `OpenTelemetry` that is currently vulned.
So I would say in its current state it should be marked obsolete then deleted.

Alternatively, maybe it could be modified to provide a tight integration with an `OpenTelemetry` collector, but that's beyond the scope of this PR. (I don't use OpenTelemetry myself, I consume the ActivitySource with Elastic APM).