### PR TITLE
Open up TickerQ.Utilities for third-party persistence providers

### DIFF
--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -11,6 +11,7 @@ using TickerQ.EntityFrameworkCore.DbContextFactory;
 using TickerQ.Utilities;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Infrastructure;
 using TickerQ.Utilities.Interfaces;
 using TickerQ.Utilities.Models;
 

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
+using System;
 using Microsoft.EntityFrameworkCore.Query;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Enums;
@@ -8,88 +6,8 @@ using TickerQ.Utilities.Models;
 
 namespace TickerQ.EntityFrameworkCore.Infrastructure
 {
-    internal static class MappingExtensions
+    internal static class EfUpdateExtensions
     {
-        public static Expression<Func<TCronTicker, CronTickerEntity>> ForCronTickerExpressions<TCronTicker>()
-            where TCronTicker : CronTickerEntity, new()
-            => e => new CronTickerEntity
-            {
-                Id = e.Id,
-                Expression = e.Expression,
-                Function = e.Function,
-                RetryIntervals = e.RetryIntervals,
-                Retries = e.Retries,
-                IsEnabled = e.IsEnabled
-            };
-
-        internal static Expression<Func<TTimeTicker, TimeTickerEntity>> ForQueueTimeTickers<TTimeTicker>()
-            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
-            => e => new TimeTickerEntity
-            {
-                Id = e.Id,
-                Function = e.Function,
-                Retries = e.Retries,
-                RetryIntervals = e.RetryIntervals,
-                UpdatedAt = e.UpdatedAt,
-                ParentId = e.ParentId,
-                ExecutionTime = e.ExecutionTime,
-                Children = e.Children.Select(ch => new TimeTickerEntity
-                {
-                    Id = ch.Id,
-                    Function = ch.Function,
-                    Retries = ch.Retries,
-                    RetryIntervals = ch.RetryIntervals,
-                    RunCondition = ch.RunCondition,
-                    Children = ch.Children.Select(gch => new TimeTickerEntity
-                    {
-                        Function = gch.Function,
-                        Retries = gch.Retries,
-                        RetryIntervals = gch.RetryIntervals,
-                        Id = gch.Id,
-                        RunCondition = gch.RunCondition
-                    }).ToArray()
-                }).ToArray()
-            };
-
-        internal static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
-            ForQueueCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
-            where TCronTicker : CronTickerEntity, new()
-            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
-            => e => new CronTickerOccurrenceEntity<TCronTicker>
-            {
-                Id = e.Id,
-                UpdatedAt = e.UpdatedAt,
-                CronTickerId = e.CronTickerId,
-                ExecutionTime = e.ExecutionTime,
-                CronTicker = new TCronTicker
-                {
-                    Id = e.CronTicker.Id,
-                    Function = e.CronTicker.Function,
-                    RetryIntervals = e.CronTicker.RetryIntervals,
-                    Retries = e.CronTicker.Retries
-                }
-            };
-
-        internal static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
-            ForLatestQueuedCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
-            where TCronTicker : CronTickerEntity, new()
-            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
-            => e => new CronTickerOccurrenceEntity<TCronTicker>
-            {
-                Id = e.Id,
-                CreatedAt = e.CreatedAt,
-                CronTickerId = e.CronTickerId,
-                ExecutionTime = e.ExecutionTime,
-                CronTicker = new TCronTicker
-                {
-                    Id = e.CronTicker.Id,
-                    Function = e.CronTicker.Function,
-                    Expression = e.CronTicker.Expression,
-                    RetryIntervals = e.CronTicker.RetryIntervals,
-                    Retries = e.CronTicker.Retries
-                }
-            };
-
         internal static void UpdateCronTickerOccurrence<TCronTicker>(
             this UpdateSettersBuilder<CronTickerOccurrenceEntity<TCronTicker>> setters,
             InternalFunctionContext functionContext)
@@ -97,7 +15,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
         {
             var propsToUpdate = functionContext.GetPropsToUpdate();
 
-            // STATUS / SKIPPED
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.Status)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
@@ -110,32 +27,27 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.SkippedReason, functionContext.ExceptionDetails);
             }
 
-            // EXECUTED_AT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutedAt)))
             {
                 setters.SetProperty(x => x.ExecutedAt, functionContext.ExecutedAt);
             }
 
-            // EXCEPTION DETAILS
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExceptionDetails)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
                 setters.SetProperty(x => x.ExceptionMessage, functionContext.ExceptionDetails);
             }
 
-            // ELAPSED_TIME
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ElapsedTime)))
             {
                 setters.SetProperty(x => x.ElapsedTime, functionContext.ElapsedTime);
             }
 
-            // RETRY COUNT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.RetryCount)))
             {
                 setters.SetProperty(x => x.RetryCount, functionContext.RetryCount);
             }
 
-            // RELEASE LOCK
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ReleaseLock)))
             {
                 setters
@@ -143,7 +55,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.LockedAt, (DateTime?)null);
             }
 
-            // EXECUTION TIME
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutionTime)))
             {
                 setters.SetProperty(x => x.ExecutionTime, functionContext.ExecutionTime);
@@ -156,7 +67,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
         {
             var propsToUpdate = functionContext.GetPropsToUpdate();
 
-            // STATUS / SKIPPED
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.Status)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
@@ -169,32 +79,27 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.SkippedReason, functionContext.ExceptionDetails);
             }
 
-            // EXECUTED_AT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutedAt)))
             {
                 setters.SetProperty(x => x.ExecutedAt, functionContext.ExecutedAt);
             }
 
-            // EXCEPTION DETAILS
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExceptionDetails)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
                 setters.SetProperty(x => x.ExceptionMessage, functionContext.ExceptionDetails);
             }
 
-            // ELAPSED_TIME
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ElapsedTime)))
             {
                 setters.SetProperty(x => x.ElapsedTime, functionContext.ElapsedTime);
             }
 
-            // RETRY COUNT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.RetryCount)))
             {
                 setters.SetProperty(x => x.RetryCount, functionContext.RetryCount);
             }
 
-            // RELEASE LOCK
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ReleaseLock)))
             {
                 setters
@@ -202,7 +107,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.LockedAt, (DateTime?)null);
             }
 
-            // UPDATED_AT ALWAYS
             setters.SetProperty(x => x.UpdatedAt, updatedAt);
         }
     }

--- a/src/TickerQ.Utilities/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.Utilities/Infrastructure/MappingExtensions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.Utilities.Infrastructure
+{
+    public static class MappingExtensions
+    {
+        public static Expression<Func<TCronTicker, CronTickerEntity>> ForCronTickerExpressions<TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+            => e => new CronTickerEntity
+            {
+                Id = e.Id,
+                Expression = e.Expression,
+                Function = e.Function,
+                RetryIntervals = e.RetryIntervals,
+                Retries = e.Retries,
+                IsEnabled = e.IsEnabled
+            };
+
+        public static Expression<Func<TTimeTicker, TimeTickerEntity>> ForQueueTimeTickers<TTimeTicker>()
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            => e => new TimeTickerEntity
+            {
+                Id = e.Id,
+                Function = e.Function,
+                Retries = e.Retries,
+                RetryIntervals = e.RetryIntervals,
+                UpdatedAt = e.UpdatedAt,
+                ParentId = e.ParentId,
+                ExecutionTime = e.ExecutionTime,
+                Children = e.Children.Select(ch => new TimeTickerEntity
+                {
+                    Id = ch.Id,
+                    Function = ch.Function,
+                    Retries = ch.Retries,
+                    RetryIntervals = ch.RetryIntervals,
+                    RunCondition = ch.RunCondition,
+                    Children = ch.Children.Select(gch => new TimeTickerEntity
+                    {
+                        Function = gch.Function,
+                        Retries = gch.Retries,
+                        RetryIntervals = gch.RetryIntervals,
+                        Id = gch.Id,
+                        RunCondition = gch.RunCondition
+                    }).ToArray()
+                }).ToArray()
+            };
+
+        public static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
+            ForQueueCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
+            => e => new CronTickerOccurrenceEntity<TCronTicker>
+            {
+                Id = e.Id,
+                UpdatedAt = e.UpdatedAt,
+                CronTickerId = e.CronTickerId,
+                ExecutionTime = e.ExecutionTime,
+                CronTicker = new TCronTicker
+                {
+                    Id = e.CronTicker.Id,
+                    Function = e.CronTicker.Function,
+                    RetryIntervals = e.CronTicker.RetryIntervals,
+                    Retries = e.CronTicker.Retries
+                }
+            };
+
+        public static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
+            ForLatestQueuedCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
+            => e => new CronTickerOccurrenceEntity<TCronTicker>
+            {
+                Id = e.Id,
+                CreatedAt = e.CreatedAt,
+                CronTickerId = e.CronTickerId,
+                ExecutionTime = e.ExecutionTime,
+                CronTicker = new TCronTicker
+                {
+                    Id = e.CronTicker.Id,
+                    Function = e.CronTicker.Function,
+                    Expression = e.CronTicker.Expression,
+                    RetryIntervals = e.CronTicker.RetryIntervals,
+                    Retries = e.CronTicker.Retries
+                }
+            };
+    }
+}

--- a/src/TickerQ.Utilities/Properties/AssemblyInfo.cs
+++ b/src/TickerQ.Utilities/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 
 [assembly: InternalsVisibleTo("TickerQ")]
 [assembly: InternalsVisibleTo("TickerQ.EntityFrameworkCore")]
+[assembly: InternalsVisibleTo("TickerQ.MongoDB")]
 [assembly: InternalsVisibleTo("TickerQ.Dashboard")]
 [assembly: InternalsVisibleTo("TickerQ.Tests")]
 [assembly: InternalsVisibleTo("TickerQ.SDK")]


### PR DESCRIPTION
I'm building a MongoDB persistence provider as a separate NuGet package (https://github.com/alexjamesbrown/TickerQ.MongoDB) that implements `ITickerPersistenceProvider` over the raw MongoDB.Driver, mirroring how TickerQ.EntityFrameworkCore plugs in. 

Two small changes to Utilities let third-party providers consume it cleanly from NuGet.

**1. Move the entity-projection helpers from EF to Utilities**

`ForCronTickerExpressions`, `ForQueueTimeTickers`, `ForQueueCronTickerOccurrence`, `ForLatestQueuedCronTickerOccurrence` are pure entity-graph projections with no EF Core dependency. 
They now live in src/TickerQ.Utilities/Infrastructure/MappingExtensions.cs (public) so any provider can reuse the canonical projection shape rather than re-implementing it.

The EF-specific SetPropertyCalls helpers (`UpdateTimeTicker` / `UpdateCronTickerOccurrence` on `UpdateSettersBuilder`) stay in the EF project. Their containing class is renamed from `MappingExtensions` to `EfUpdateExtensions` to avoid an ambiguous-name conflict with the new Utilities class at call sites - both are internal, so this is purely internal cleanup.

`BasePersistenceProvider` gains `using TickerQ.Utilities.Infrastructure;` so existing `MappingExtensions.ForXxx<T>()` call sites resolve to the new location with no body changes.

**2. Grant InternalsVisibleTo("TickerQ.MongoDB")**

TickerQ.Utilities already grants visibility to TickerQ.EntityFrameworkCore so persistence code can write entity audit fields with internal setters (Status, LockHolder, LockedAt, UpdatedAt, InitIdentifier, CreatedAt, ParentId) and use the internal ExternalProviderConfigServiceAction on TickerOptionsBuilder<,>. Granting the same to TickerQ.MongoDB lets a parallel non-EF provider plug in the same way.

Verified locally: EF builds clean, all 74 EF tests pass with the refactor.