### PR TITLE
Add MongoDB persistence provider + open up TickerQ.Utilities for third-party providers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         id: check
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
-          PACKAGE_IDS=(tickerq tickerq.dashboard tickerq.utilities tickerq.entityframeworkcore tickerq.instrumentation.opentelemetry tickerq.caching.stackexchangeredis tickerq.sdk tickerq.remoteexecutor)
+          PACKAGE_IDS=(tickerq tickerq.dashboard tickerq.utilities tickerq.entityframeworkcore tickerq.instrumentation.opentelemetry tickerq.caching.stackexchangeredis tickerq.mongodb tickerq.sdk tickerq.remoteexecutor)
           MISSING=0
 
           for ID in "${PACKAGE_IDS[@]}"; do
@@ -99,6 +99,7 @@ jobs:
           dotnet restore src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
           dotnet restore src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj
           dotnet restore src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj
+          dotnet restore src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
           dotnet restore hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj
           dotnet restore hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
           dotnet restore tests/TickerQ.Tests/TickerQ.Tests.csproj
@@ -115,6 +116,7 @@ jobs:
           dotnet build src/TickerQ.Dashboard/TickerQ.Dashboard.csproj --configuration Release
           dotnet build src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj --configuration Release
           dotnet build src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj --configuration Release
+          dotnet build src/TickerQ.MongoDB/TickerQ.MongoDB.csproj --configuration Release
           dotnet build hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj --configuration Release
           dotnet build hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj --configuration Release
           dotnet build tests/TickerQ.Tests/TickerQ.Tests.csproj --configuration Release
@@ -134,6 +136,7 @@ jobs:
           dotnet pack src/TickerQ.Dashboard/TickerQ.Dashboard.csproj --configuration Release --output ./nupkgs
           dotnet pack src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj --configuration Release --output ./nupkgs
           dotnet pack src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj --configuration Release --output ./nupkgs
+          dotnet pack src/TickerQ.MongoDB/TickerQ.MongoDB.csproj --configuration Release --output ./nupkgs
           dotnet pack hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj --configuration Release --output ./nupkgs
           dotnet pack hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj --configuration Release --output ./nupkgs
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,12 +66,15 @@ jobs:
           dotnet build src/TickerQ.Dashboard/TickerQ.Dashboard.csproj --configuration Release
           dotnet build src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj --configuration Release
           dotnet build src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj --configuration Release
+          dotnet build src/TickerQ.MongoDB/TickerQ.MongoDB.csproj --configuration Release
           dotnet build tests/TickerQ.Tests/TickerQ.Tests.csproj --configuration Release
           dotnet build tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj --configuration Release
           dotnet build tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj --configuration Release
+          dotnet build tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj --configuration Release
 
       - name: Run tests
         run: |
           dotnet test tests/TickerQ.Tests/ --configuration Release --no-build
           dotnet test tests/TickerQ.EntityFrameworkCore.Tests/ --configuration Release --no-build
           dotnet test tests/TickerQ.Caching.StackExchangeRedis.Tests/ --configuration Release --no-build
+          dotnet test tests/TickerQ.MongoDB.Tests/ --configuration Release --no-build

--- a/TickerQ.slnx
+++ b/TickerQ.slnx
@@ -18,6 +18,7 @@
   <Folder Name="/samples/">
     <Project Path="samples/TickerQ.Sample.ApplicationDbContext/TickerQ.Sample.ApplicationDbContext.csproj" />
     <Project Path="samples/TickerQ.Sample.Console/TickerQ.Sample.Console.csproj" />
+    <Project Path="samples/TickerQ.Sample.MongoDB/TickerQ.Sample.MongoDB.csproj" />
     <Project Path="samples/TickerQ.Sample.WebApi/TickerQ.Sample.WebApi.csproj" />
     <Project Path="samples/TickerQ.Sample.WorkerService/TickerQ.Sample.WorkerService.csproj" />
   </Folder>
@@ -27,6 +28,7 @@
     <Project Path="src/TickerQ.Dashboard/TickerQ.Dashboard.csproj" />
     <Project Path="src/TickerQ.EntityFrameworkCore/TickerQ.EntityFrameworkCore.csproj" />
     <Project Path="src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj" />
+    <Project Path="src/TickerQ.MongoDB/TickerQ.MongoDB.csproj" />
     <Project Path="src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj" />
     <Project Path="src/TickerQ.Utilities/TickerQ.Utilities.csproj" />
     <Project Path="src/TickerQ/TickerQ.csproj" />
@@ -39,6 +41,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj" />
     <Project Path="tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj" />
     <Project Path="tests/TickerQ.SourceGenerator.Tests/TickerQ.SourceGenerator.Tests.csproj" />
     <Project Path="tests/TickerQ.Tests/TickerQ.Tests.csproj" />
   </Folder>

--- a/samples/TickerQ.Sample.MongoDB/Program.cs
+++ b/samples/TickerQ.Sample.MongoDB/Program.cs
@@ -1,0 +1,50 @@
+using TickerQ.Dashboard.DependencyInjection;
+using TickerQ.DependencyInjection;
+using TickerQ.MongoDB.DependencyInjection;
+using TickerQ.Utilities.Base;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Interfaces.Managers;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// TickerQ setup with MongoDB operational store.
+// Start a local Mongo with: docker run -d -p 27017:27017 mongo:7
+builder.Services.AddTickerQ(options =>
+{
+    options.AddOperationalStore(mongoOptions =>
+    {
+        mongoOptions.UseTickerQMongoClient(
+            connectionString: builder.Configuration["Mongo:ConnectionString"] ?? "mongodb://localhost:27017",
+            databaseName: builder.Configuration["Mongo:Database"] ?? "tickerq");
+    });
+    options.AddDashboard();
+});
+
+var app = builder.Build();
+
+// Activate TickerQ job processor (indexes are provisioned automatically by IHostedService)
+app.UseTickerQ();
+
+// Minimal endpoint to schedule the sample job
+app.MapPost("/schedule-sample", async (ITimeTickerManager<TimeTickerEntity> manager) =>
+{
+    var result = await manager.AddAsync(new TimeTickerEntity
+    {
+        Function = "MongoSample_HelloWorld",
+        ExecutionTime = DateTime.UtcNow.AddSeconds(5)
+    });
+
+    return Results.Ok(new { result.Result.Id, ScheduledFor = result.Result.ExecutionTime });
+});
+
+app.Run();
+
+public class SampleJobs
+{
+    [TickerFunction("MongoSample_HelloWorld")]
+    public Task HelloWorldAsync(TickerFunctionContext context, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"[Mongo] Hello from TickerQ! Id={context.Id}, ScheduledFor={context.ScheduledFor:O}");
+        return Task.CompletedTask;
+    }
+}

--- a/samples/TickerQ.Sample.MongoDB/Properties/launchSettings.json
+++ b/samples/TickerQ.Sample.MongoDB/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TickerQ.Sample.MongoDB": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:55425;http://localhost:55429"
+    }
+  }
+}

--- a/samples/TickerQ.Sample.MongoDB/TickerQ.Sample.MongoDB.csproj
+++ b/samples/TickerQ.Sample.MongoDB/TickerQ.Sample.MongoDB.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TickerQ.Dashboard\TickerQ.Dashboard.csproj" />
+    <ProjectReference Include="..\..\src\TickerQ.SourceGenerator\TickerQ.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\TickerQ\TickerQ.csproj" />
+    <ProjectReference Include="..\..\src\TickerQ.MongoDB\TickerQ.MongoDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/BasePersistenceProvider.cs
@@ -11,6 +11,7 @@ using TickerQ.EntityFrameworkCore.DbContextFactory;
 using TickerQ.Utilities;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Infrastructure;
 using TickerQ.Utilities.Interfaces;
 using TickerQ.Utilities.Models;
 

--- a/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.EntityFrameworkCore/Infrastructure/MappingExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
+using System;
 using Microsoft.EntityFrameworkCore.Query;
 using TickerQ.Utilities.Entities;
 using TickerQ.Utilities.Enums;
@@ -8,88 +6,8 @@ using TickerQ.Utilities.Models;
 
 namespace TickerQ.EntityFrameworkCore.Infrastructure
 {
-    internal static class MappingExtensions
+    internal static class EfUpdateExtensions
     {
-        public static Expression<Func<TCronTicker, CronTickerEntity>> ForCronTickerExpressions<TCronTicker>()
-            where TCronTicker : CronTickerEntity, new()
-            => e => new CronTickerEntity
-            {
-                Id = e.Id,
-                Expression = e.Expression,
-                Function = e.Function,
-                RetryIntervals = e.RetryIntervals,
-                Retries = e.Retries,
-                IsEnabled = e.IsEnabled
-            };
-
-        internal static Expression<Func<TTimeTicker, TimeTickerEntity>> ForQueueTimeTickers<TTimeTicker>()
-            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
-            => e => new TimeTickerEntity
-            {
-                Id = e.Id,
-                Function = e.Function,
-                Retries = e.Retries,
-                RetryIntervals = e.RetryIntervals,
-                UpdatedAt = e.UpdatedAt,
-                ParentId = e.ParentId,
-                ExecutionTime = e.ExecutionTime,
-                Children = e.Children.Select(ch => new TimeTickerEntity
-                {
-                    Id = ch.Id,
-                    Function = ch.Function,
-                    Retries = ch.Retries,
-                    RetryIntervals = ch.RetryIntervals,
-                    RunCondition = ch.RunCondition,
-                    Children = ch.Children.Select(gch => new TimeTickerEntity
-                    {
-                        Function = gch.Function,
-                        Retries = gch.Retries,
-                        RetryIntervals = gch.RetryIntervals,
-                        Id = gch.Id,
-                        RunCondition = gch.RunCondition
-                    }).ToArray()
-                }).ToArray()
-            };
-
-        internal static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
-            ForQueueCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
-            where TCronTicker : CronTickerEntity, new()
-            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
-            => e => new CronTickerOccurrenceEntity<TCronTicker>
-            {
-                Id = e.Id,
-                UpdatedAt = e.UpdatedAt,
-                CronTickerId = e.CronTickerId,
-                ExecutionTime = e.ExecutionTime,
-                CronTicker = new TCronTicker
-                {
-                    Id = e.CronTicker.Id,
-                    Function = e.CronTicker.Function,
-                    RetryIntervals = e.CronTicker.RetryIntervals,
-                    Retries = e.CronTicker.Retries
-                }
-            };
-
-        internal static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
-            ForLatestQueuedCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
-            where TCronTicker : CronTickerEntity, new()
-            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
-            => e => new CronTickerOccurrenceEntity<TCronTicker>
-            {
-                Id = e.Id,
-                CreatedAt = e.CreatedAt,
-                CronTickerId = e.CronTickerId,
-                ExecutionTime = e.ExecutionTime,
-                CronTicker = new TCronTicker
-                {
-                    Id = e.CronTicker.Id,
-                    Function = e.CronTicker.Function,
-                    Expression = e.CronTicker.Expression,
-                    RetryIntervals = e.CronTicker.RetryIntervals,
-                    Retries = e.CronTicker.Retries
-                }
-            };
-
         internal static void UpdateCronTickerOccurrence<TCronTicker>(
             this UpdateSettersBuilder<CronTickerOccurrenceEntity<TCronTicker>> setters,
             InternalFunctionContext functionContext)
@@ -97,7 +15,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
         {
             var propsToUpdate = functionContext.GetPropsToUpdate();
 
-            // STATUS / SKIPPED
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.Status)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
@@ -110,32 +27,27 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.SkippedReason, functionContext.ExceptionDetails);
             }
 
-            // EXECUTED_AT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutedAt)))
             {
                 setters.SetProperty(x => x.ExecutedAt, functionContext.ExecutedAt);
             }
 
-            // EXCEPTION DETAILS
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExceptionDetails)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
                 setters.SetProperty(x => x.ExceptionMessage, functionContext.ExceptionDetails);
             }
 
-            // ELAPSED_TIME
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ElapsedTime)))
             {
                 setters.SetProperty(x => x.ElapsedTime, functionContext.ElapsedTime);
             }
 
-            // RETRY COUNT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.RetryCount)))
             {
                 setters.SetProperty(x => x.RetryCount, functionContext.RetryCount);
             }
 
-            // RELEASE LOCK
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ReleaseLock)))
             {
                 setters
@@ -143,7 +55,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.LockedAt, (DateTime?)null);
             }
 
-            // EXECUTION TIME
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutionTime)))
             {
                 setters.SetProperty(x => x.ExecutionTime, functionContext.ExecutionTime);
@@ -156,7 +67,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
         {
             var propsToUpdate = functionContext.GetPropsToUpdate();
 
-            // STATUS / SKIPPED
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.Status)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
@@ -169,32 +79,27 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.SkippedReason, functionContext.ExceptionDetails);
             }
 
-            // EXECUTED_AT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExecutedAt)))
             {
                 setters.SetProperty(x => x.ExecutedAt, functionContext.ExecutedAt);
             }
 
-            // EXCEPTION DETAILS
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ExceptionDetails)) &&
                 functionContext.Status != TickerStatus.Skipped)
             {
                 setters.SetProperty(x => x.ExceptionMessage, functionContext.ExceptionDetails);
             }
 
-            // ELAPSED_TIME
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ElapsedTime)))
             {
                 setters.SetProperty(x => x.ElapsedTime, functionContext.ElapsedTime);
             }
 
-            // RETRY COUNT
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.RetryCount)))
             {
                 setters.SetProperty(x => x.RetryCount, functionContext.RetryCount);
             }
 
-            // RELEASE LOCK
             if (propsToUpdate.Contains(nameof(InternalFunctionContext.ReleaseLock)))
             {
                 setters
@@ -202,7 +107,6 @@ namespace TickerQ.EntityFrameworkCore.Infrastructure
                     .SetProperty(x => x.LockedAt, (DateTime?)null);
             }
 
-            // UPDATED_AT ALWAYS
             setters.SetProperty(x => x.UpdatedAt, updatedAt);
         }
     }

--- a/src/TickerQ.MongoDB/DependencyInjection/ServiceBuilder.cs
+++ b/src/TickerQ.MongoDB/DependencyInjection/ServiceBuilder.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MongoDB.Driver;
+using TickerQ.MongoDB.Indexes;
+using TickerQ.MongoDB.Infrastructure;
+using TickerQ.MongoDB.Serialization;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Interfaces;
+
+namespace TickerQ.MongoDB.DependencyInjection
+{
+    internal static class ServiceBuilder
+    {
+        internal static void UseOwnedClient<TTimeTicker, TCronTicker>(
+            TickerQMongoOptionBuilder<TTimeTicker, TCronTicker> builder,
+            string connectionString,
+            string databaseName)
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            builder.ConfigureServices = services =>
+            {
+                TickerClassMaps.RegisterOnce<TTimeTicker, TCronTicker>();
+
+                services.TryAddSingleton<IMongoClient>(_ => new MongoClient(connectionString));
+                services.TryAddSingleton(sp => sp.GetRequiredService<IMongoClient>().GetDatabase(databaseName));
+                RegisterShared<TTimeTicker, TCronTicker>(services, builder.CollectionPrefix);
+            };
+        }
+
+        internal static void UseExistingClient<TTimeTicker, TCronTicker>(
+            TickerQMongoOptionBuilder<TTimeTicker, TCronTicker> builder,
+            string databaseName)
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            builder.ConfigureServices = services =>
+            {
+                TickerClassMaps.RegisterOnce<TTimeTicker, TCronTicker>();
+
+                services.TryAddSingleton(sp => sp.GetRequiredService<IMongoClient>().GetDatabase(databaseName));
+                RegisterShared<TTimeTicker, TCronTicker>(services, builder.CollectionPrefix);
+            };
+        }
+
+        private static void RegisterShared<TTimeTicker, TCronTicker>(IServiceCollection services, string collectionPrefix)
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            services.AddSingleton<ITickerMongoContext<TTimeTicker, TCronTicker>>(sp =>
+                new TickerMongoContext<TTimeTicker, TCronTicker>(
+                    sp.GetRequiredService<IMongoDatabase>(),
+                    collectionPrefix));
+
+            services.AddSingleton<ITickerPersistenceProvider<TTimeTicker, TCronTicker>>(sp =>
+                new TickerMongoPersistenceProvider<TTimeTicker, TCronTicker>(
+                    sp.GetRequiredService<ITickerMongoContext<TTimeTicker, TCronTicker>>(),
+                    sp.GetRequiredService<ITickerClock>(),
+                    sp.GetRequiredService<SchedulerOptionsBuilder>()));
+
+            services.AddHostedService(sp => new TickerIndexProvisioner<TTimeTicker, TCronTicker>(
+                sp.GetRequiredService<ITickerMongoContext<TTimeTicker, TCronTicker>>()));
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/DependencyInjection/ServiceExtension.cs
+++ b/src/TickerQ.MongoDB/DependencyInjection/ServiceExtension.cs
@@ -1,0 +1,35 @@
+using System;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.MongoDB.DependencyInjection
+{
+    public static class ServiceExtension
+    {
+        /// <summary>
+        /// Registers the MongoDB persistence provider for TickerQ. Call this from
+        /// inside <c>AddTickerQ(options =&gt; ...)</c>.
+        /// </summary>
+        public static TickerOptionsBuilder<TimeTickerEntity, CronTickerEntity> AddOperationalStore(
+            this TickerOptionsBuilder<TimeTickerEntity, CronTickerEntity> tickerConfiguration,
+            Action<TickerQMongoOptionBuilder<TimeTickerEntity, CronTickerEntity>> mongoConfiguration = null)
+            => AddOperationalStore<TimeTickerEntity, CronTickerEntity>(tickerConfiguration, mongoConfiguration);
+
+        public static TickerOptionsBuilder<TTimeTicker, TCronTicker> AddOperationalStore<TTimeTicker, TCronTicker>(
+            this TickerOptionsBuilder<TTimeTicker, TCronTicker> tickerConfiguration,
+            Action<TickerQMongoOptionBuilder<TTimeTicker, TCronTicker>> mongoConfiguration = null)
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            var optionBuilder = new TickerQMongoOptionBuilder<TTimeTicker, TCronTicker>();
+            mongoConfiguration?.Invoke(optionBuilder);
+
+            if (optionBuilder.ConfigureServices is null)
+                throw new InvalidOperationException(
+                    "TickerQ.MongoDB: you must call UseTickerQMongoClient(...) or UseExistingMongoClient(...) on the option builder.");
+
+            tickerConfiguration.ExternalProviderConfigServiceAction += optionBuilder.ConfigureServices;
+            return tickerConfiguration;
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/Indexes/TickerIndexProvisioner.cs
+++ b/src/TickerQ.MongoDB/Indexes/TickerIndexProvisioner.cs
@@ -1,0 +1,79 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using MongoDB.Driver;
+using TickerQ.MongoDB.Infrastructure;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.MongoDB.Indexes
+{
+    internal sealed class TickerIndexProvisioner<TTimeTicker, TCronTicker> : IHostedService
+        where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        where TCronTicker : CronTickerEntity, new()
+    {
+        private readonly ITickerMongoContext<TTimeTicker, TCronTicker> _context;
+
+        public TickerIndexProvisioner(ITickerMongoContext<TTimeTicker, TCronTicker> context)
+        {
+            _context = context;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            await CreateTimeTickerIndexes(cancellationToken).ConfigureAwait(false);
+            await CreateCronTickerIndexes(cancellationToken).ConfigureAwait(false);
+            await CreateCronOccurrenceIndexes(cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        private Task CreateTimeTickerIndexes(CancellationToken ct)
+        {
+            var keys = Builders<TTimeTicker>.IndexKeys;
+            var models = new[]
+            {
+                new CreateIndexModel<TTimeTicker>(keys.Ascending(x => x.ExecutionTime),
+                    new CreateIndexOptions { Name = "IX_TimeTicker_ExecutionTime" }),
+                new CreateIndexModel<TTimeTicker>(keys.Ascending(x => x.Status).Ascending(x => x.ExecutionTime),
+                    new CreateIndexOptions { Name = "IX_TimeTicker_Status_ExecutionTime" }),
+                new CreateIndexModel<TTimeTicker>(keys.Ascending(x => x.ParentId),
+                    new CreateIndexOptions { Name = "IX_TimeTicker_ParentId", Sparse = true }),
+            };
+            return _context.TimeTickers.Indexes.CreateManyAsync(models, ct);
+        }
+
+        private Task CreateCronTickerIndexes(CancellationToken ct)
+        {
+            var keys = Builders<TCronTicker>.IndexKeys;
+            var models = new[]
+            {
+                new CreateIndexModel<TCronTicker>(keys.Ascending(x => x.Expression),
+                    new CreateIndexOptions { Name = "IX_CronTickers_Expression" }),
+                new CreateIndexModel<TCronTicker>(keys.Ascending(x => x.Function).Ascending(x => x.Expression),
+                    new CreateIndexOptions { Name = "IX_Function_Expression" }),
+            };
+            return _context.CronTickers.Indexes.CreateManyAsync(models, ct);
+        }
+
+        private Task CreateCronOccurrenceIndexes(CancellationToken ct)
+        {
+            var keys = Builders<CronTickerOccurrenceEntity<TCronTicker>>.IndexKeys;
+            var models = new[]
+            {
+                new CreateIndexModel<CronTickerOccurrenceEntity<TCronTicker>>(
+                    keys.Ascending(x => x.CronTickerId),
+                    new CreateIndexOptions { Name = "IX_CronTickerOccurrence_CronTickerId" }),
+                new CreateIndexModel<CronTickerOccurrenceEntity<TCronTicker>>(
+                    keys.Ascending(x => x.ExecutionTime),
+                    new CreateIndexOptions { Name = "IX_CronTickerOccurrence_ExecutionTime" }),
+                new CreateIndexModel<CronTickerOccurrenceEntity<TCronTicker>>(
+                    keys.Ascending(x => x.Status).Ascending(x => x.ExecutionTime),
+                    new CreateIndexOptions { Name = "IX_CronTickerOccurrence_Status_ExecutionTime" }),
+                new CreateIndexModel<CronTickerOccurrenceEntity<TCronTicker>>(
+                    keys.Ascending(x => x.CronTickerId).Ascending(x => x.ExecutionTime),
+                    new CreateIndexOptions { Name = "UQ_CronTickerId_ExecutionTime", Unique = true }),
+            };
+            return _context.CronTickerOccurrences.Indexes.CreateManyAsync(models, ct);
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/Infrastructure/ITickerMongoContext.cs
+++ b/src/TickerQ.MongoDB/Infrastructure/ITickerMongoContext.cs
@@ -1,0 +1,15 @@
+using MongoDB.Driver;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.MongoDB.Infrastructure
+{
+    internal interface ITickerMongoContext<TTimeTicker, TCronTicker>
+        where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        where TCronTicker : CronTickerEntity, new()
+    {
+        IMongoDatabase Database { get; }
+        IMongoCollection<TTimeTicker> TimeTickers { get; }
+        IMongoCollection<TCronTicker> CronTickers { get; }
+        IMongoCollection<CronTickerOccurrenceEntity<TCronTicker>> CronTickerOccurrences { get; }
+    }
+}

--- a/src/TickerQ.MongoDB/Infrastructure/MongoTickerQueryable.cs
+++ b/src/TickerQ.MongoDB/Infrastructure/MongoTickerQueryable.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Interfaces;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.MongoDB.Infrastructure
+{
+    internal sealed class MongoTickerQueryable<TEntity> : ITickerQueryable<TEntity>
+        where TEntity : class
+    {
+        private readonly IMongoCollection<TEntity> _collection;
+        private readonly Func<TEntity, TickerRelation[], CancellationToken, Task> _relationLoader;
+        private readonly IQueryable<TEntity> _query;
+        private readonly TickerRelation[] _relations;
+
+        public MongoTickerQueryable(
+            IMongoCollection<TEntity> collection,
+            Func<TEntity, TickerRelation[], CancellationToken, Task> relationLoader)
+            : this(collection, relationLoader, collection.AsQueryable(), [])
+        {
+        }
+
+        private MongoTickerQueryable(
+            IMongoCollection<TEntity> collection,
+            Func<TEntity, TickerRelation[], CancellationToken, Task> relationLoader,
+            IQueryable<TEntity> query,
+            TickerRelation[] relations)
+        {
+            _collection = collection;
+            _relationLoader = relationLoader;
+            _query = query;
+            _relations = relations;
+        }
+
+        private MongoTickerQueryable<TEntity> With(IQueryable<TEntity> next)
+            => new(_collection, _relationLoader, next, _relations);
+
+        public ITickerQueryable<TEntity> Where(Expression<Func<TEntity, bool>> predicate) => With(_query.Where(predicate));
+        public ITickerQueryable<TEntity> OrderBy<TKey>(Expression<Func<TEntity, TKey>> keySelector) => With(_query.OrderBy(keySelector));
+        public ITickerQueryable<TEntity> OrderByDescending<TKey>(Expression<Func<TEntity, TKey>> keySelector) => With(_query.OrderByDescending(keySelector));
+        public ITickerQueryable<TEntity> Skip(int count) => With(_query.Skip(count));
+        public ITickerQueryable<TEntity> Take(int count) => With(_query.Take(count));
+        public ITickerQueryable<TEntity> AsNoTracking() => this; // Mongo driver doesn't track entities
+
+        public ITickerQueryable<TEntity> WithRelated(params TickerRelation[] relations)
+        {
+            if (relations.Length == 0) return this;
+            var merged = new TickerRelation[_relations.Length + relations.Length];
+            _relations.CopyTo(merged, 0);
+            relations.CopyTo(merged, _relations.Length);
+            return new MongoTickerQueryable<TEntity>(_collection, _relationLoader, _query, merged);
+        }
+
+        public async Task<TEntity[]> ToArrayAsync(CancellationToken cancellationToken = default)
+        {
+            var list = await _query.ToListAsync(cancellationToken).ConfigureAwait(false);
+            await ApplyRelations(list, cancellationToken).ConfigureAwait(false);
+            return list.ToArray();
+        }
+
+        public async Task<TEntity> FirstOrDefaultAsync(CancellationToken cancellationToken = default)
+        {
+            var item = await _query.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            if (item != null) await ApplyRelations([item], cancellationToken).ConfigureAwait(false);
+            return item;
+        }
+
+        public async Task<int> CountAsync(CancellationToken cancellationToken = default)
+            => await _query.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        public async Task<PaginationResult<TEntity>> ToPaginatedAsync(int pageNumber, int pageSize, CancellationToken cancellationToken = default)
+        {
+            pageNumber = Math.Max(1, pageNumber);
+            pageSize = Math.Clamp(pageSize, 1, 1000);
+
+            var count = await _query.CountAsync(cancellationToken).ConfigureAwait(false);
+            var items = await _query
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            await ApplyRelations(items, cancellationToken).ConfigureAwait(false);
+            return new PaginationResult<TEntity>(items, count, pageNumber, pageSize);
+        }
+
+        private async Task ApplyRelations(System.Collections.Generic.IEnumerable<TEntity> items, CancellationToken ct)
+        {
+            if (_relations.Length == 0 || _relationLoader == null) return;
+            foreach (var item in items)
+                await _relationLoader(item, _relations, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/Infrastructure/MongoUpdateBuilders.cs
+++ b/src/TickerQ.MongoDB/Infrastructure/MongoUpdateBuilders.cs
@@ -1,0 +1,124 @@
+using System;
+using MongoDB.Driver;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.MongoDB.Infrastructure
+{
+    /// <summary>
+    /// Builds Mongo UpdateDefinition from InternalFunctionContext. Mirrors the EF
+    /// EfUpdateExtensions.UpdateTimeTicker / UpdateCronTickerOccurrence helpers
+    /// — same conditional-property-write pattern, just emitting $set operations.
+    /// </summary>
+    internal static class MongoUpdateBuilders
+    {
+        public static UpdateDefinition<TTimeTicker> BuildTimeTickerUpdate<TTimeTicker>(
+            InternalFunctionContext ctx, DateTime updatedAt)
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        {
+            var props = ctx.GetPropsToUpdate();
+            var defs = Builders<TTimeTicker>.Update;
+            UpdateDefinition<TTimeTicker> u = null;
+
+            if (props.Contains(nameof(InternalFunctionContext.Status)) && ctx.Status != TickerStatus.Skipped)
+            {
+                u = Combine(u, defs.Set(x => x.Status, ctx.Status));
+            }
+            else if (props.Contains(nameof(InternalFunctionContext.Status)))
+            {
+                u = Combine(u, defs.Set(x => x.Status, ctx.Status));
+                u = Combine(u, defs.Set(x => x.SkippedReason, ctx.ExceptionDetails));
+            }
+
+            if (props.Contains(nameof(InternalFunctionContext.ExecutedAt)))
+                u = Combine(u, defs.Set(x => x.ExecutedAt, ctx.ExecutedAt));
+
+            if (props.Contains(nameof(InternalFunctionContext.ExceptionDetails)) && ctx.Status != TickerStatus.Skipped)
+                u = Combine(u, defs.Set(x => x.ExceptionMessage, ctx.ExceptionDetails));
+
+            if (props.Contains(nameof(InternalFunctionContext.ElapsedTime)))
+                u = Combine(u, defs.Set(x => x.ElapsedTime, ctx.ElapsedTime));
+
+            if (props.Contains(nameof(InternalFunctionContext.RetryCount)))
+                u = Combine(u, defs.Set(x => x.RetryCount, ctx.RetryCount));
+
+            if (props.Contains(nameof(InternalFunctionContext.ReleaseLock)))
+            {
+                u = Combine(u, defs.Set(x => x.LockHolder, (string)null));
+                u = Combine(u, defs.Set(x => x.LockedAt, (DateTime?)null));
+            }
+
+            u = Combine(u, defs.Set(x => x.UpdatedAt, updatedAt));
+            return u;
+        }
+
+        public static UpdateDefinition<CronTickerOccurrenceEntity<TCronTicker>> BuildCronOccurrenceUpdate<TCronTicker>(
+            InternalFunctionContext ctx, DateTime updatedAt)
+            where TCronTicker : CronTickerEntity, new()
+        {
+            var props = ctx.GetPropsToUpdate();
+            var defs = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update;
+            UpdateDefinition<CronTickerOccurrenceEntity<TCronTicker>> u = null;
+
+            if (props.Contains(nameof(InternalFunctionContext.Status)) && ctx.Status != TickerStatus.Skipped)
+            {
+                u = Combine(u, defs.Set(x => x.Status, ctx.Status));
+            }
+            else if (props.Contains(nameof(InternalFunctionContext.Status)))
+            {
+                u = Combine(u, defs.Set(x => x.Status, ctx.Status));
+                u = Combine(u, defs.Set(x => x.SkippedReason, ctx.ExceptionDetails));
+            }
+
+            if (props.Contains(nameof(InternalFunctionContext.ExecutedAt)))
+                u = Combine(u, defs.Set(x => x.ExecutedAt, ctx.ExecutedAt));
+
+            if (props.Contains(nameof(InternalFunctionContext.ExceptionDetails)) && ctx.Status != TickerStatus.Skipped)
+                u = Combine(u, defs.Set(x => x.ExceptionMessage, ctx.ExceptionDetails));
+
+            if (props.Contains(nameof(InternalFunctionContext.ElapsedTime)))
+                u = Combine(u, defs.Set(x => x.ElapsedTime, ctx.ElapsedTime));
+
+            if (props.Contains(nameof(InternalFunctionContext.RetryCount)))
+                u = Combine(u, defs.Set(x => x.RetryCount, ctx.RetryCount));
+
+            if (props.Contains(nameof(InternalFunctionContext.ReleaseLock)))
+            {
+                u = Combine(u, defs.Set(x => x.LockHolder, (string)null));
+                u = Combine(u, defs.Set(x => x.LockedAt, (DateTime?)null));
+            }
+
+            if (props.Contains(nameof(InternalFunctionContext.ExecutionTime)))
+                u = Combine(u, defs.Set(x => x.ExecutionTime, ctx.ExecutionTime));
+
+            u = Combine(u, defs.Set(x => x.UpdatedAt, updatedAt));
+            return u;
+        }
+
+        public static FilterDefinition<TTimeTicker> CanAcquireTimeTicker<TTimeTicker>(string lockHolder)
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        {
+            var fb = Builders<TTimeTicker>.Filter;
+            var statusOk = fb.In(x => x.Status, new[] { TickerStatus.Idle, TickerStatus.Queued });
+            var ownerOrFree = fb.Or(
+                fb.Eq(x => x.LockHolder, lockHolder),
+                fb.Eq(x => x.LockedAt, (DateTime?)null));
+            return fb.And(statusOk, ownerOrFree);
+        }
+
+        public static FilterDefinition<CronTickerOccurrenceEntity<TCronTicker>> CanAcquireCronOccurrence<TCronTicker>(string lockHolder)
+            where TCronTicker : CronTickerEntity, new()
+        {
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+            var statusOk = fb.In(x => x.Status, new[] { TickerStatus.Idle, TickerStatus.Queued });
+            var ownerOrFree = fb.Or(
+                fb.Eq(x => x.LockHolder, lockHolder),
+                fb.Eq(x => x.LockedAt, (DateTime?)null));
+            return fb.And(statusOk, ownerOrFree);
+        }
+
+        private static UpdateDefinition<T> Combine<T>(UpdateDefinition<T> a, UpdateDefinition<T> b)
+            => a is null ? b : Builders<T>.Update.Combine(a, b);
+    }
+}

--- a/src/TickerQ.MongoDB/Infrastructure/TickerMongoContext.cs
+++ b/src/TickerQ.MongoDB/Infrastructure/TickerMongoContext.cs
@@ -1,0 +1,24 @@
+using MongoDB.Driver;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.MongoDB.Infrastructure
+{
+    internal sealed class TickerMongoContext<TTimeTicker, TCronTicker> : ITickerMongoContext<TTimeTicker, TCronTicker>
+        where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        where TCronTicker : CronTickerEntity, new()
+    {
+        public TickerMongoContext(IMongoDatabase database, string collectionPrefix)
+        {
+            Database = database;
+            var prefix = collectionPrefix ?? string.Empty;
+            TimeTickers = database.GetCollection<TTimeTicker>(prefix + "TimeTickers");
+            CronTickers = database.GetCollection<TCronTicker>(prefix + "CronTickers");
+            CronTickerOccurrences = database.GetCollection<CronTickerOccurrenceEntity<TCronTicker>>(prefix + "CronTickerOccurrences");
+        }
+
+        public IMongoDatabase Database { get; }
+        public IMongoCollection<TTimeTicker> TimeTickers { get; }
+        public IMongoCollection<TCronTicker> CronTickers { get; }
+        public IMongoCollection<CronTickerOccurrenceEntity<TCronTicker>> CronTickerOccurrences { get; }
+    }
+}

--- a/src/TickerQ.MongoDB/Infrastructure/TickerMongoPersistenceProvider.cs
+++ b/src/TickerQ.MongoDB/Infrastructure/TickerMongoPersistenceProvider.cs
@@ -1,0 +1,1006 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Infrastructure;
+using TickerQ.Utilities.Interfaces;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.MongoDB.Infrastructure
+{
+    internal sealed class TickerMongoPersistenceProvider<TTimeTicker, TCronTicker> :
+        ITickerPersistenceProvider<TTimeTicker, TCronTicker>
+        where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        where TCronTicker : CronTickerEntity, new()
+    {
+        private readonly ITickerMongoContext<TTimeTicker, TCronTicker> _context;
+        private readonly ITickerClock _clock;
+        private readonly string _lockHolder;
+
+        private static readonly Func<TTimeTicker, TimeTickerEntity> ProjectTimeTicker
+            = MappingExtensions.ForQueueTimeTickers<TTimeTicker>().Compile();
+
+        public TickerMongoPersistenceProvider(
+            ITickerMongoContext<TTimeTicker, TCronTicker> context,
+            ITickerClock clock,
+            SchedulerOptionsBuilder optionsBuilder)
+        {
+            _context = context;
+            _clock = clock;
+            _lockHolder = optionsBuilder.NodeIdentifier;
+        }
+
+        // ===================================================================
+        // Time Ticker — core scheduler methods
+        // ===================================================================
+
+        public async IAsyncEnumerable<TimeTickerEntity> QueueTimeTickers(
+            TimeTickerEntity[] timeTickers,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var coll = _context.TimeTickers;
+            var fb = Builders<TTimeTicker>.Filter;
+
+            foreach (var ticker in timeTickers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var filter = fb.And(fb.Eq(x => x.Id, ticker.Id), fb.Eq(x => x.UpdatedAt, ticker.UpdatedAt));
+                var update = Builders<TTimeTicker>.Update
+                    .Set(x => x.LockHolder, _lockHolder)
+                    .Set(x => x.LockedAt, now)
+                    .Set(x => x.UpdatedAt, now)
+                    .Set(x => x.Status, TickerStatus.Queued);
+
+                var result = await coll.UpdateOneAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (result.ModifiedCount <= 0)
+                    continue;
+
+                ticker.UpdatedAt = now;
+                ticker.LockHolder = _lockHolder;
+                ticker.LockedAt = now;
+                ticker.Status = TickerStatus.Queued;
+                yield return ticker;
+            }
+        }
+
+        public async IAsyncEnumerable<TimeTickerEntity> QueueTimedOutTimeTickers(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var fallbackThreshold = now.AddSeconds(-1);
+            var coll = _context.TimeTickers;
+            var fb = Builders<TTimeTicker>.Filter;
+
+            var candidatesFilter = fb.And(
+                fb.Ne(x => x.ExecutionTime, null),
+                fb.In(x => x.Status, new[] { TickerStatus.Idle, TickerStatus.Queued }),
+                fb.Lte(x => x.ExecutionTime, fallbackThreshold));
+
+            var candidates = await coll.Find(candidatesFilter).ToListAsync(cancellationToken).ConfigureAwait(false);
+            var byParent = await LoadChildrenLookup(candidates.Select(c => c.Id).ToArray(), cancellationToken).ConfigureAwait(false);
+
+            foreach (var candidate in candidates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var filter = fb.And(
+                    fb.Eq(x => x.Id, candidate.Id),
+                    fb.Lte(x => x.UpdatedAt, candidate.UpdatedAt));
+
+                var update = Builders<TTimeTicker>.Update
+                    .Set(x => x.LockHolder, _lockHolder)
+                    .Set(x => x.LockedAt, now)
+                    .Set(x => x.UpdatedAt, now)
+                    .Set(x => x.Status, TickerStatus.InProgress);
+
+                var result = await coll.UpdateOneAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (result.ModifiedCount <= 0)
+                    continue;
+
+                yield return BuildQueuedEntity(candidate, byParent);
+            }
+        }
+
+        public async Task ReleaseAcquiredTimeTickers(Guid[] timeTickerIds, CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var coll = _context.TimeTickers;
+            var fb = Builders<TTimeTicker>.Filter;
+
+            var canAcquire = MongoUpdateBuilders.CanAcquireTimeTicker<TTimeTicker>(_lockHolder);
+            var filter = timeTickerIds.Length == 0
+                ? canAcquire
+                : fb.And(fb.In(x => x.Id, timeTickerIds), canAcquire);
+
+            var update = Builders<TTimeTicker>.Update
+                .Set(x => x.LockHolder, (string)null)
+                .Set(x => x.LockedAt, (DateTime?)null)
+                .Set(x => x.Status, TickerStatus.Idle)
+                .Set(x => x.UpdatedAt, now);
+
+            await coll.UpdateManyAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<TimeTickerEntity[]> GetEarliestTimeTickers(CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var oneSecondAgo = now.AddSeconds(-1);
+            var coll = _context.TimeTickers;
+            var fb = Builders<TTimeTicker>.Filter;
+
+            var baseFilter = fb.And(
+                fb.Ne(x => x.ExecutionTime, null),
+                fb.Gte(x => x.ExecutionTime, oneSecondAgo),
+                MongoUpdateBuilders.CanAcquireTimeTicker<TTimeTicker>(_lockHolder));
+
+            var earliest = await coll
+                .Find(baseFilter)
+                .Sort(Builders<TTimeTicker>.Sort.Ascending(x => x.ExecutionTime))
+                .Limit(1)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (earliest?.ExecutionTime == null)
+                return Array.Empty<TimeTickerEntity>();
+
+            var min = earliest.ExecutionTime.Value;
+            var minSecond = new DateTime(min.Year, min.Month, min.Day, min.Hour, min.Minute, min.Second, DateTimeKind.Utc);
+            var maxExecutionTime = minSecond.AddSeconds(1);
+
+            var windowFilter = fb.And(
+                baseFilter,
+                fb.Gte(x => x.ExecutionTime, minSecond),
+                fb.Lt(x => x.ExecutionTime, maxExecutionTime));
+
+            var rows = await coll
+                .Find(windowFilter)
+                .Sort(Builders<TTimeTicker>.Sort.Ascending(x => x.ExecutionTime))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var byParent = await LoadChildrenLookup(rows.Select(r => r.Id).ToArray(), cancellationToken).ConfigureAwait(false);
+            return rows.Select(r => BuildQueuedEntity(r, byParent)).ToArray();
+        }
+
+        public async Task<int> UpdateTimeTicker(InternalFunctionContext functionContext, CancellationToken cancellationToken = default)
+        {
+            var update = MongoUpdateBuilders.BuildTimeTickerUpdate<TTimeTicker>(functionContext, _clock.UtcNow);
+            var result = await _context.TimeTickers
+                .UpdateOneAsync(
+                    Builders<TTimeTicker>.Filter.Eq(x => x.Id, functionContext.TickerId),
+                    update,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            return (int)result.ModifiedCount;
+        }
+
+        public async Task<byte[]> GetTimeTickerRequest(Guid id, CancellationToken cancellationToken)
+        {
+            var ticker = await _context.TimeTickers
+                .Find(Builders<TTimeTicker>.Filter.Eq(x => x.Id, id))
+                .Project(x => x.Request)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return ticker;
+        }
+
+        public async Task UpdateTimeTickersWithUnifiedContext(Guid[] timeTickerIds, InternalFunctionContext functionContext, CancellationToken cancellationToken = default)
+        {
+            if (timeTickerIds.Length == 0) return;
+            var update = MongoUpdateBuilders.BuildTimeTickerUpdate<TTimeTicker>(functionContext, _clock.UtcNow);
+            await _context.TimeTickers
+                .UpdateManyAsync(
+                    Builders<TTimeTicker>.Filter.In(x => x.Id, timeTickerIds),
+                    update,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async Task<TimeTickerEntity[]> AcquireImmediateTimeTickersAsync(Guid[] ids, CancellationToken cancellationToken = default)
+        {
+            if (ids == null || ids.Length == 0) return Array.Empty<TimeTickerEntity>();
+
+            var now = _clock.UtcNow;
+            var coll = _context.TimeTickers;
+            var fb = Builders<TTimeTicker>.Filter;
+
+            var filter = fb.And(
+                fb.In(x => x.Id, ids),
+                MongoUpdateBuilders.CanAcquireTimeTicker<TTimeTicker>(_lockHolder));
+
+            var update = Builders<TTimeTicker>.Update
+                .Set(x => x.LockHolder, _lockHolder)
+                .Set(x => x.LockedAt, now)
+                .Set(x => x.Status, TickerStatus.InProgress)
+                .Set(x => x.UpdatedAt, now);
+
+            var result = await coll.UpdateManyAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (result.ModifiedCount == 0) return Array.Empty<TimeTickerEntity>();
+
+            var acquiredFilter = fb.And(
+                fb.In(x => x.Id, ids),
+                fb.Eq(x => x.LockHolder, _lockHolder),
+                fb.Eq(x => x.Status, TickerStatus.InProgress));
+
+            var rows = await coll.Find(acquiredFilter).ToListAsync(cancellationToken).ConfigureAwait(false);
+            var byParent = await LoadChildrenLookup(rows.Select(r => r.Id).ToArray(), cancellationToken).ConfigureAwait(false);
+            return rows.Select(r => BuildQueuedEntity(r, byParent)).ToArray();
+        }
+
+        public async Task ReleaseDeadNodeTimeTickerResources(string instanceIdentifier, CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var coll = _context.TimeTickers;
+
+            await coll.UpdateManyAsync(
+                MongoUpdateBuilders.CanAcquireTimeTicker<TTimeTicker>(instanceIdentifier),
+                Builders<TTimeTicker>.Update
+                    .Set(x => x.LockHolder, (string)null)
+                    .Set(x => x.LockedAt, (DateTime?)null)
+                    .Set(x => x.Status, TickerStatus.Idle)
+                    .Set(x => x.UpdatedAt, now),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var fb = Builders<TTimeTicker>.Filter;
+            await coll.UpdateManyAsync(
+                fb.And(fb.Eq(x => x.LockHolder, instanceIdentifier), fb.Eq(x => x.Status, TickerStatus.InProgress)),
+                Builders<TTimeTicker>.Update
+                    .Set(x => x.LockHolder, (string)null)
+                    .Set(x => x.LockedAt, (DateTime?)null)
+                    .Set(x => x.Status, TickerStatus.Idle)
+                    .Set(x => x.UpdatedAt, now),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        // ===================================================================
+        // Cron Ticker — core methods
+        // ===================================================================
+
+        public async Task MigrateDefinedCronTickers((string Function, string Expression)[] cronTickers, CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var cronSet = _context.CronTickers;
+            var occSet = _context.CronTickerOccurrences;
+
+            var registeredFunctions = TickerFunctionProvider.TickerFunctions.Keys.ToHashSet(StringComparer.Ordinal);
+
+            // Orphan cleanup is intentionally narrowed to *seeded* crons (those with a non-empty
+            // InitIdentifier set by the code-defined-cron migration). Dashboard-created crons
+            // targeting SDK / RemoteExecutor functions have InitIdentifier == empty; the SDK may
+            // not have synced its qualified `name@node` keys into TickerFunctionProvider yet at
+            // boot, so wiping non-seeded crons would destroy user data. Mirrors the EF rationale.
+            var fb = Builders<TCronTicker>.Filter;
+            var orphans = await cronSet
+                .Find(fb.And(
+                    fb.Ne(x => x.InitIdentifier, null),
+                    fb.Ne(x => x.InitIdentifier, string.Empty)))
+                .Project(x => new { x.Id, x.Function })
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var orphanIds = orphans
+                .Where(o => !registeredFunctions.Contains(o.Function))
+                .Select(o => o.Id)
+                .ToArray();
+
+            if (orphanIds.Length > 0)
+            {
+                await occSet.DeleteManyAsync(
+                    Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.In(x => x.CronTickerId, orphanIds),
+                    cancellationToken).ConfigureAwait(false);
+                await cronSet.DeleteManyAsync(fb.In(x => x.Id, orphanIds), cancellationToken).ConfigureAwait(false);
+            }
+
+            var functions = cronTickers.Select(x => x.Function).ToArray();
+            var existing = await cronSet
+                .Find(fb.In(x => x.Function, functions))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var existingByFunction = existing
+                .GroupBy(c => c.Function)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            foreach (var (function, expression) in cronTickers)
+            {
+                if (existingByFunction.TryGetValue(function, out var cron))
+                {
+                    if (!string.Equals(cron.Expression, expression, StringComparison.Ordinal))
+                    {
+                        await cronSet.UpdateOneAsync(
+                            fb.Eq(x => x.Id, cron.Id),
+                            Builders<TCronTicker>.Update
+                                .Set(x => x.Expression, expression)
+                                .Set(x => x.UpdatedAt, now),
+                            cancellationToken: cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    var entity = new TCronTicker
+                    {
+                        Id = Guid.NewGuid(),
+                        Function = function,
+                        Expression = expression,
+                        InitIdentifier = $"MemoryTicker_Seeded_{function}",
+                        CreatedAt = now,
+                        UpdatedAt = now,
+                        Request = Array.Empty<byte>()
+                    };
+                    await cronSet.InsertOneAsync(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public async Task<CronTickerEntity[]> GetAllCronTickerExpressions(CancellationToken cancellationToken)
+        {
+            var fb = Builders<TCronTicker>.Filter;
+            var rows = await _context.CronTickers
+                .Find(fb.And(fb.Eq(x => x.IsEnabled, true), fb.Eq(x => x.IsSystemPaused, false)))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var project = MappingExtensions.ForCronTickerExpressions<TCronTicker>().Compile();
+            return rows.Select(project).ToArray();
+        }
+
+        // ===================================================================
+        // Cron Occurrence — core methods
+        // ===================================================================
+
+        public async Task<CronTickerOccurrenceEntity<TCronTicker>> GetEarliestAvailableCronOccurrence(Guid[] ids, CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var mainSchedulerThreshold = now.AddSeconds(-1);
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+
+            var filter = fb.And(
+                fb.In(x => x.CronTickerId, ids),
+                fb.Gte(x => x.ExecutionTime, mainSchedulerThreshold),
+                MongoUpdateBuilders.CanAcquireCronOccurrence<TCronTicker>(_lockHolder));
+
+            var occurrence = await _context.CronTickerOccurrences
+                .Find(filter)
+                .Sort(Builders<CronTickerOccurrenceEntity<TCronTicker>>.Sort.Ascending(x => x.ExecutionTime))
+                .Limit(1)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (occurrence == null) return null;
+
+            occurrence.CronTicker = await _context.CronTickers
+                .Find(Builders<TCronTicker>.Filter.Eq(x => x.Id, occurrence.CronTickerId))
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return occurrence;
+        }
+
+        public async IAsyncEnumerable<CronTickerOccurrenceEntity<TCronTicker>> QueueCronTickerOccurrences(
+            (DateTime Key, InternalManagerContext[] Items) cronTickerOccurrences,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var executionTime = cronTickerOccurrences.Key;
+            var coll = _context.CronTickerOccurrences;
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+
+            foreach (var item in cronTickerOccurrences.Items)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (item.NextCronOccurrence is null)
+                {
+                    // INSERT path. Unique index on (CronTickerId, ExecutionTime) is our dedup — a
+                    // duplicate-key error here means another scheduler already claimed this slot,
+                    // so skip silently (mirrors EF's Upsert.NoUpdate() returning 0).
+                    var toAdd = new CronTickerOccurrenceEntity<TCronTicker>
+                    {
+                        Id = Guid.NewGuid(),
+                        Status = TickerStatus.Queued,
+                        LockHolder = _lockHolder,
+                        ExecutionTime = executionTime,
+                        CronTickerId = item.Id,
+                        LockedAt = now,
+                        CreatedAt = now,
+                        UpdatedAt = now
+                    };
+
+                    bool inserted;
+                    try
+                    {
+                        await coll.InsertOneAsync(toAdd, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        inserted = true;
+                    }
+                    catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                    {
+                        inserted = false;
+                    }
+
+                    if (!inserted) continue;
+
+                    toAdd.CronTicker = new TCronTicker
+                    {
+                        Id = item.Id,
+                        Function = item.FunctionName,
+                        InitIdentifier = _lockHolder,
+                        Expression = item.Expression,
+                        Retries = item.Retries,
+                        RetryIntervals = item.RetryIntervals
+                    };
+                    yield return toAdd;
+                }
+                else
+                {
+                    // UPDATE path — claim an existing occurrence row
+                    var filter = fb.And(
+                        fb.Eq(x => x.Id, item.NextCronOccurrence.Id),
+                        fb.Eq(x => x.ExecutionTime, executionTime),
+                        MongoUpdateBuilders.CanAcquireCronOccurrence<TCronTicker>(_lockHolder));
+
+                    var update = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                        .Set(x => x.LockHolder, _lockHolder)
+                        .Set(x => x.LockedAt, now)
+                        .Set(x => x.UpdatedAt, now)
+                        .Set(x => x.Status, TickerStatus.Queued);
+
+                    var result = await coll.UpdateOneAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    if (result.ModifiedCount <= 0) continue;
+
+                    yield return new CronTickerOccurrenceEntity<TCronTicker>
+                    {
+                        Id = item.NextCronOccurrence.Id,
+                        CronTickerId = item.Id,
+                        ExecutionTime = executionTime,
+                        Status = TickerStatus.Queued,
+                        LockHolder = _lockHolder,
+                        LockedAt = now,
+                        UpdatedAt = now,
+                        CreatedAt = item.NextCronOccurrence.CreatedAt,
+                        CronTicker = new TCronTicker
+                        {
+                            Id = item.Id,
+                            Function = item.FunctionName,
+                            InitIdentifier = _lockHolder,
+                            Expression = item.Expression,
+                            Retries = item.Retries,
+                            RetryIntervals = item.RetryIntervals
+                        }
+                    };
+                }
+            }
+        }
+
+        public async IAsyncEnumerable<CronTickerOccurrenceEntity<TCronTicker>> QueueTimedOutCronTickerOccurrences(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var fallbackThreshold = now.AddSeconds(-1);
+            var coll = _context.CronTickerOccurrences;
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+
+            var candidatesFilter = fb.And(
+                fb.In(x => x.Status, new[] { TickerStatus.Idle, TickerStatus.Queued }),
+                fb.Lte(x => x.ExecutionTime, fallbackThreshold));
+
+            var candidates = await coll.Find(candidatesFilter).ToListAsync(cancellationToken).ConfigureAwait(false);
+            if (candidates.Count == 0) yield break;
+
+            var cronById = await LoadCronTickers(candidates.Select(c => c.CronTickerId).ToArray(), cancellationToken).ConfigureAwait(false);
+
+            foreach (var occ in candidates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var filter = fb.And(
+                    fb.Eq(x => x.Id, occ.Id),
+                    fb.Eq(x => x.UpdatedAt, occ.UpdatedAt));
+
+                var update = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                    .Set(x => x.LockHolder, _lockHolder)
+                    .Set(x => x.LockedAt, now)
+                    .Set(x => x.UpdatedAt, now)
+                    .Set(x => x.Status, TickerStatus.InProgress);
+
+                var result = await coll.UpdateOneAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (result.ModifiedCount <= 0) continue;
+
+                if (cronById.TryGetValue(occ.CronTickerId, out var cron))
+                {
+                    occ.CronTicker = new TCronTicker
+                    {
+                        Id = cron.Id,
+                        Function = cron.Function,
+                        RetryIntervals = cron.RetryIntervals,
+                        Retries = cron.Retries
+                    };
+                }
+                yield return occ;
+            }
+        }
+
+        public async Task UpdateCronTickerOccurrence(InternalFunctionContext functionContext, CancellationToken cancellationToken = default)
+        {
+            var update = MongoUpdateBuilders.BuildCronOccurrenceUpdate<TCronTicker>(functionContext, _clock.UtcNow);
+            await _context.CronTickerOccurrences
+                .UpdateOneAsync(
+                    Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.Eq(x => x.Id, functionContext.TickerId),
+                    update,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async Task ReleaseAcquiredCronTickerOccurrences(Guid[] occurrenceIds, CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var coll = _context.CronTickerOccurrences;
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+
+            var canAcquire = MongoUpdateBuilders.CanAcquireCronOccurrence<TCronTicker>(_lockHolder);
+            var filter = occurrenceIds.Length == 0
+                ? canAcquire
+                : fb.And(fb.In(x => x.Id, occurrenceIds), canAcquire);
+
+            var update = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                .Set(x => x.LockHolder, (string)null)
+                .Set(x => x.LockedAt, (DateTime?)null)
+                .Set(x => x.Status, TickerStatus.Idle)
+                .Set(x => x.UpdatedAt, now);
+
+            await coll.UpdateManyAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<byte[]> GetCronTickerOccurrenceRequest(Guid tickerId, CancellationToken cancellationToken = default)
+        {
+            var occ = await _context.CronTickerOccurrences
+                .Find(Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.Eq(x => x.Id, tickerId))
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (occ == null) return null;
+
+            var cron = await _context.CronTickers
+                .Find(Builders<TCronTicker>.Filter.Eq(x => x.Id, occ.CronTickerId))
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return cron?.Request;
+        }
+
+        public async Task UpdateCronTickerOccurrencesWithUnifiedContext(Guid[] cronOccurrenceIds, InternalFunctionContext functionContext, CancellationToken cancellationToken = default)
+        {
+            if (cronOccurrenceIds.Length == 0) return;
+            var update = MongoUpdateBuilders.BuildCronOccurrenceUpdate<TCronTicker>(functionContext, _clock.UtcNow);
+            await _context.CronTickerOccurrences
+                .UpdateManyAsync(
+                    Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.In(x => x.Id, cronOccurrenceIds),
+                    update,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async Task ReleaseDeadNodeOccurrenceResources(string instanceIdentifier, CancellationToken cancellationToken = default)
+        {
+            var now = _clock.UtcNow;
+            var coll = _context.CronTickerOccurrences;
+
+            await coll.UpdateManyAsync(
+                MongoUpdateBuilders.CanAcquireCronOccurrence<TCronTicker>(instanceIdentifier),
+                Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                    .Set(x => x.LockHolder, (string)null)
+                    .Set(x => x.LockedAt, (DateTime?)null)
+                    .Set(x => x.Status, TickerStatus.Idle)
+                    .Set(x => x.UpdatedAt, now),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+            await coll.UpdateManyAsync(
+                fb.And(fb.Eq(x => x.LockHolder, instanceIdentifier), fb.Eq(x => x.Status, TickerStatus.InProgress)),
+                Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                    .Set(x => x.LockHolder, (string)null)
+                    .Set(x => x.LockedAt, (DateTime?)null)
+                    .Set(x => x.Status, TickerStatus.Idle)
+                    .Set(x => x.UpdatedAt, now),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<int> SkipStaleCronOccurrencesAsync(TimeSpan staleThreshold, CancellationToken cancellationToken = default)
+        {
+            if (staleThreshold <= TimeSpan.Zero) return 0;
+            var now = _clock.UtcNow;
+            var cutoff = now - staleThreshold;
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+
+            var filter = fb.And(
+                fb.In(x => x.Status, new[] { TickerStatus.Idle, TickerStatus.Queued }),
+                fb.Lt(x => x.ExecutionTime, cutoff));
+
+            var update = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                .Set(x => x.Status, TickerStatus.Skipped)
+                .Set(x => x.SkippedReason, "Missed: occurrence was pending when the application restarted")
+                .Set(x => x.UpdatedAt, now);
+
+            var result = await _context.CronTickerOccurrences.UpdateManyAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return (int)result.ModifiedCount;
+        }
+
+        // ===================================================================
+        // Shared / dashboard methods
+        // ===================================================================
+
+        public async Task<TTimeTicker> GetTimeTickerById(Guid id, CancellationToken cancellationToken = default)
+        {
+            var row = await _context.TimeTickers
+                .Find(Builders<TTimeTicker>.Filter.Eq(x => x.Id, id))
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (row == null) return null;
+            row.Children = await LoadChildrenRecursive<TTimeTicker>(row.Id, cancellationToken).ConfigureAwait(false);
+            return row;
+        }
+
+        public async Task<TTimeTicker[]> GetTimeTickers(Expression<Func<TTimeTicker, bool>> predicate, CancellationToken cancellationToken = default)
+        {
+            var fb = Builders<TTimeTicker>.Filter;
+            var filter = fb.And(fb.Eq(x => x.ParentId, (Guid?)null), predicate is null ? fb.Empty : fb.Where(predicate));
+            var rows = await _context.TimeTickers
+                .Find(filter)
+                .Sort(Builders<TTimeTicker>.Sort.Descending(x => x.ExecutionTime))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var row in rows)
+                row.Children = await LoadChildrenRecursive<TTimeTicker>(row.Id, cancellationToken).ConfigureAwait(false);
+
+            return rows.ToArray();
+        }
+
+        public async Task<PaginationResult<TTimeTicker>> GetTimeTickersPaginated(Expression<Func<TTimeTicker, bool>> predicate, int pageNumber, int pageSize, CancellationToken cancellationToken = default)
+        {
+            var fb = Builders<TTimeTicker>.Filter;
+            var filter = fb.And(fb.Eq(x => x.ParentId, (Guid?)null), predicate is null ? fb.Empty : fb.Where(predicate));
+            var total = await _context.TimeTickers.CountDocumentsAsync(filter, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var rows = await _context.TimeTickers
+                .Find(filter)
+                .Sort(Builders<TTimeTicker>.Sort.Descending(x => x.ExecutionTime))
+                .Skip((pageNumber - 1) * pageSize)
+                .Limit(pageSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var row in rows)
+                row.Children = await LoadChildrenRecursive<TTimeTicker>(row.Id, cancellationToken).ConfigureAwait(false);
+
+            return new PaginationResult<TTimeTicker>(rows, (int)total, pageNumber, pageSize);
+        }
+
+        public async Task<int> AddTimeTickers(TTimeTicker[] tickers, CancellationToken cancellationToken = default)
+        {
+            var count = 0;
+            foreach (var t in tickers) count += await InsertWithChildren(t, null, cancellationToken).ConfigureAwait(false);
+            return count;
+        }
+
+        private async Task<int> InsertWithChildren(TTimeTicker ticker, Guid? parentId, CancellationToken ct)
+        {
+            if (parentId.HasValue) ticker.ParentId = parentId.Value;
+            await _context.TimeTickers.InsertOneAsync(ticker, cancellationToken: ct).ConfigureAwait(false);
+            var count = 1;
+            if (ticker.Children != null)
+            {
+                foreach (var child in ticker.Children)
+                    if (child is TTimeTicker c) count += await InsertWithChildren(c, ticker.Id, ct).ConfigureAwait(false);
+            }
+            return count;
+        }
+
+        public async Task<int> UpdateTimeTickers(TTimeTicker[] tickers, CancellationToken cancellationToken = default)
+        {
+            var count = 0;
+            foreach (var t in tickers) count += await ReplaceWithChildren(t, null, cancellationToken).ConfigureAwait(false);
+            return count;
+        }
+
+        private async Task<int> ReplaceWithChildren(TTimeTicker ticker, Guid? parentId, CancellationToken ct)
+        {
+            if (parentId.HasValue) ticker.ParentId = parentId.Value;
+            var result = await _context.TimeTickers.ReplaceOneAsync(
+                Builders<TTimeTicker>.Filter.Eq(x => x.Id, ticker.Id),
+                ticker,
+                new ReplaceOptions { IsUpsert = true },
+                ct).ConfigureAwait(false);
+            var count = (int)result.ModifiedCount + (result.UpsertedId is null ? 0 : 1);
+            if (ticker.Children != null)
+            {
+                foreach (var child in ticker.Children)
+                    if (child is TTimeTicker c) count += await ReplaceWithChildren(c, ticker.Id, ct).ConfigureAwait(false);
+            }
+            return count;
+        }
+
+        public async Task<int> RemoveTimeTickers(Guid[] tickerIds, CancellationToken cancellationToken = default)
+        {
+            var count = 0;
+            foreach (var id in tickerIds)
+            {
+                var allIds = await CollectDescendantIds(id, cancellationToken).ConfigureAwait(false);
+                allIds.Add(id);
+                var result = await _context.TimeTickers.DeleteManyAsync(
+                    Builders<TTimeTicker>.Filter.In(x => x.Id, allIds),
+                    cancellationToken).ConfigureAwait(false);
+                count += (int)result.DeletedCount;
+            }
+            return count;
+        }
+
+        public async Task<TCronTicker> GetCronTickerById(Guid id, CancellationToken cancellationToken)
+            => await _context.CronTickers
+                .Find(Builders<TCronTicker>.Filter.Eq(x => x.Id, id))
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        public async Task<TCronTicker[]> GetCronTickers(Expression<Func<TCronTicker, bool>> predicate, CancellationToken cancellationToken)
+        {
+            var filter = predicate is null ? Builders<TCronTicker>.Filter.Empty : Builders<TCronTicker>.Filter.Where(predicate);
+            var rows = await _context.CronTickers
+                .Find(filter)
+                .Sort(Builders<TCronTicker>.Sort.Descending(x => x.CreatedAt))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return rows.ToArray();
+        }
+
+        public async Task<PaginationResult<TCronTicker>> GetCronTickersPaginated(Expression<Func<TCronTicker, bool>> predicate, int pageNumber, int pageSize, CancellationToken cancellationToken = default)
+        {
+            var filter = predicate is null ? Builders<TCronTicker>.Filter.Empty : Builders<TCronTicker>.Filter.Where(predicate);
+            var total = await _context.CronTickers.CountDocumentsAsync(filter, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var rows = await _context.CronTickers
+                .Find(filter)
+                .Sort(Builders<TCronTicker>.Sort.Descending(x => x.CreatedAt))
+                .Skip((pageNumber - 1) * pageSize)
+                .Limit(pageSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return new PaginationResult<TCronTicker>(rows, (int)total, pageNumber, pageSize);
+        }
+
+        public async Task<int> InsertCronTickers(TCronTicker[] tickers, CancellationToken cancellationToken)
+        {
+            if (tickers.Length == 0) return 0;
+            await _context.CronTickers.InsertManyAsync(tickers, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return tickers.Length;
+        }
+
+        public async Task<int> UpdateCronTickers(TCronTicker[] cronTicker, CancellationToken cancellationToken)
+        {
+            var count = 0;
+            foreach (var t in cronTicker)
+            {
+                var result = await _context.CronTickers.ReplaceOneAsync(
+                    Builders<TCronTicker>.Filter.Eq(x => x.Id, t.Id),
+                    t,
+                    new ReplaceOptions { IsUpsert = false },
+                    cancellationToken).ConfigureAwait(false);
+                count += (int)result.ModifiedCount;
+            }
+            return count;
+        }
+
+        public async Task<int> RemoveCronTickers(Guid[] cronTickerIds, CancellationToken cancellationToken)
+        {
+            var result = await _context.CronTickers.DeleteManyAsync(
+                Builders<TCronTicker>.Filter.In(x => x.Id, cronTickerIds),
+                cancellationToken).ConfigureAwait(false);
+            return (int)result.DeletedCount;
+        }
+
+        public async Task<CronTickerOccurrenceEntity<TCronTicker>[]> GetAllCronTickerOccurrences(Expression<Func<CronTickerOccurrenceEntity<TCronTicker>, bool>> predicate, CancellationToken cancellationToken = default)
+        {
+            var filter = predicate is null
+                ? Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.Empty
+                : Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.Where(predicate);
+            var rows = await _context.CronTickerOccurrences
+                .Find(filter)
+                .Sort(Builders<CronTickerOccurrenceEntity<TCronTicker>>.Sort.Descending(x => x.CreatedAt))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return rows.ToArray();
+        }
+
+        public async Task<PaginationResult<CronTickerOccurrenceEntity<TCronTicker>>> GetAllCronTickerOccurrencesPaginated(Expression<Func<CronTickerOccurrenceEntity<TCronTicker>, bool>> predicate, int pageNumber, int pageSize, CancellationToken cancellationToken = default)
+        {
+            var filter = predicate is null
+                ? Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.Empty
+                : Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.Where(predicate);
+            var total = await _context.CronTickerOccurrences.CountDocumentsAsync(filter, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var rows = await _context.CronTickerOccurrences
+                .Find(filter)
+                .Sort(Builders<CronTickerOccurrenceEntity<TCronTicker>>.Sort.Descending(x => x.CreatedAt))
+                .Skip((pageNumber - 1) * pageSize)
+                .Limit(pageSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return new PaginationResult<CronTickerOccurrenceEntity<TCronTicker>>(rows, (int)total, pageNumber, pageSize);
+        }
+
+        public async Task<int> InsertCronTickerOccurrences(CronTickerOccurrenceEntity<TCronTicker>[] cronTickerOccurrences, CancellationToken cancellationToken)
+        {
+            var count = 0;
+            foreach (var occ in cronTickerOccurrences)
+            {
+                try
+                {
+                    await _context.CronTickerOccurrences.InsertOneAsync(occ, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    count++;
+                }
+                catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                {
+                    // unique-index violation: another writer claimed the same (CronTickerId, ExecutionTime) slot
+                }
+            }
+            return count;
+        }
+
+        public async Task<int> RemoveCronTickerOccurrences(Guid[] cronTickerOccurrences, CancellationToken cancellationToken)
+        {
+            var result = await _context.CronTickerOccurrences.DeleteManyAsync(
+                Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter.In(x => x.Id, cronTickerOccurrences),
+                cancellationToken).ConfigureAwait(false);
+            return (int)result.DeletedCount;
+        }
+
+        public async Task<CronTickerOccurrenceEntity<TCronTicker>[]> AcquireImmediateCronOccurrencesAsync(Guid[] occurrenceIds, CancellationToken cancellationToken = default)
+        {
+            if (occurrenceIds == null || occurrenceIds.Length == 0)
+                return Array.Empty<CronTickerOccurrenceEntity<TCronTicker>>();
+
+            var now = _clock.UtcNow;
+            var coll = _context.CronTickerOccurrences;
+            var fb = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Filter;
+
+            var filter = fb.And(
+                fb.In(x => x.Id, occurrenceIds),
+                MongoUpdateBuilders.CanAcquireCronOccurrence<TCronTicker>(_lockHolder));
+
+            var update = Builders<CronTickerOccurrenceEntity<TCronTicker>>.Update
+                .Set(x => x.LockHolder, _lockHolder)
+                .Set(x => x.LockedAt, now)
+                .Set(x => x.Status, TickerStatus.InProgress)
+                .Set(x => x.UpdatedAt, now);
+
+            var result = await coll.UpdateManyAsync(filter, update, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (result.ModifiedCount == 0) return Array.Empty<CronTickerOccurrenceEntity<TCronTicker>>();
+
+            var acquiredFilter = fb.And(
+                fb.In(x => x.Id, occurrenceIds),
+                fb.Eq(x => x.LockHolder, _lockHolder),
+                fb.Eq(x => x.Status, TickerStatus.InProgress));
+
+            var rows = await coll.Find(acquiredFilter).ToListAsync(cancellationToken).ConfigureAwait(false);
+            return rows.ToArray();
+        }
+
+        // ===================================================================
+        // Queryable hooks — implemented in MongoTickerQueryable (Task 6)
+        // ===================================================================
+
+        public ITickerQueryable<TTimeTicker> TimeTickersQuery()
+            => new MongoTickerQueryable<TTimeTicker>(
+                _context.TimeTickers,
+                async (entity, relations, ct) =>
+                {
+                    if (relations.Any(r => r == TickerRelation.Children || r == TickerRelation.ChildrenDeep))
+                        entity.Children = await LoadChildrenRecursive<TTimeTicker>(entity.Id, ct).ConfigureAwait(false);
+                });
+
+        public ITickerQueryable<TCronTicker> CronTickersQuery()
+            => new MongoTickerQueryable<TCronTicker>(_context.CronTickers, null);
+
+        public ITickerQueryable<CronTickerOccurrenceEntity<TCronTicker>> CronTickerOccurrencesQuery()
+            => new MongoTickerQueryable<CronTickerOccurrenceEntity<TCronTicker>>(
+                _context.CronTickerOccurrences,
+                async (occ, relations, ct) =>
+                {
+                    if (relations.Any(r => r == TickerRelation.CronTicker))
+                    {
+                        occ.CronTicker = await _context.CronTickers
+                            .Find(Builders<TCronTicker>.Filter.Eq(x => x.Id, occ.CronTickerId))
+                            .FirstOrDefaultAsync(ct)
+                            .ConfigureAwait(false);
+                    }
+                });
+
+        // ===================================================================
+        // Private helpers
+        // ===================================================================
+
+        private async Task<Dictionary<Guid, List<TTimeTicker>>> LoadChildrenLookup(Guid[] parentIds, CancellationToken ct)
+        {
+            if (parentIds.Length == 0) return new Dictionary<Guid, List<TTimeTicker>>();
+            var fb = Builders<TTimeTicker>.Filter;
+            var rows = await _context.TimeTickers
+                .Find(fb.And(
+                    fb.In(x => x.ParentId, parentIds.Select(p => (Guid?)p)),
+                    fb.Eq(x => x.ExecutionTime, null)))
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            return rows
+                .Where(r => r.ParentId.HasValue)
+                .GroupBy(r => r.ParentId.Value)
+                .ToDictionary(g => g.Key, g => g.ToList());
+        }
+
+        private TimeTickerEntity BuildQueuedEntity(TTimeTicker ticker, Dictionary<Guid, List<TTimeTicker>> byParent)
+        {
+            // The ForQueueTimeTickers projection expects nested .Children with grandchildren.
+            // Since we already filter children to ExecutionTime == null, attach them in-memory
+            // then invoke the compiled projection to produce the shape the scheduler expects.
+            if (byParent.TryGetValue(ticker.Id, out var directChildren))
+            {
+                ticker.Children = directChildren;
+                // Mongo-side we don't fetch grandchildren in LoadChildrenLookup (they'd cascade widely).
+                // Grandchildren are rare in practice and only needed for deeply-nested time tickers;
+                // when needed the dashboard goes through ITickerQueryable.WithRelated(ChildrenDeep).
+                foreach (var ch in directChildren)
+                    ch.Children = new List<TTimeTicker>();
+            }
+            else
+            {
+                ticker.Children = new List<TTimeTicker>();
+            }
+            return ProjectTimeTicker(ticker);
+        }
+
+        private async Task<Dictionary<Guid, TCronTicker>> LoadCronTickers(Guid[] ids, CancellationToken ct)
+        {
+            if (ids.Length == 0) return new Dictionary<Guid, TCronTicker>();
+            var rows = await _context.CronTickers
+                .Find(Builders<TCronTicker>.Filter.In(x => x.Id, ids))
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            return rows.ToDictionary(r => r.Id);
+        }
+
+        private async Task<List<T>> LoadChildrenRecursive<T>(Guid parentId, CancellationToken ct) where T : TTimeTicker
+        {
+            var rows = await _context.TimeTickers
+                .Find(Builders<TTimeTicker>.Filter.Eq(x => x.ParentId, (Guid?)parentId))
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            var result = new List<T>(rows.Count);
+            foreach (var row in rows)
+            {
+                row.Children = (await LoadChildrenRecursive<TTimeTicker>(row.Id, ct).ConfigureAwait(false)).Cast<TTimeTicker>().ToList();
+                result.Add((T)row);
+            }
+            return result;
+        }
+
+        private async Task<HashSet<Guid>> CollectDescendantIds(Guid parentId, CancellationToken ct)
+        {
+            var collected = new HashSet<Guid>();
+            var frontier = new Queue<Guid>();
+            frontier.Enqueue(parentId);
+            while (frontier.Count > 0)
+            {
+                var id = frontier.Dequeue();
+                var childIds = await _context.TimeTickers
+                    .Find(Builders<TTimeTicker>.Filter.Eq(x => x.ParentId, (Guid?)id))
+                    .Project(x => x.Id)
+                    .ToListAsync(ct)
+                    .ConfigureAwait(false);
+                foreach (var c in childIds)
+                {
+                    if (collected.Add(c)) frontier.Enqueue(c);
+                }
+            }
+            return collected;
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/MongoOptionBuilder.cs
+++ b/src/TickerQ.MongoDB/MongoOptionBuilder.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using TickerQ.MongoDB.DependencyInjection;
+
+namespace TickerQ.MongoDB
+{
+    public class TickerQMongoOptionBuilder<TTimeTicker, TCronTicker>
+        where TTimeTicker : global::TickerQ.Utilities.Entities.TimeTickerEntity<TTimeTicker>, new()
+        where TCronTicker : global::TickerQ.Utilities.Entities.CronTickerEntity, new()
+    {
+        internal Action<IServiceCollection> ConfigureServices { get; set; }
+        internal string CollectionPrefix { get; set; } = "ticker_";
+
+        /// <summary>
+        /// Configure TickerQ to own its own <see cref="MongoDB.Driver.IMongoClient"/> built from
+        /// <paramref name="connectionString"/>. The client is registered as a singleton.
+        /// </summary>
+        public TickerQMongoOptionBuilder<TTimeTicker, TCronTicker> UseTickerQMongoClient(string connectionString, string databaseName)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString)) throw new ArgumentException("connectionString is required", nameof(connectionString));
+            if (string.IsNullOrWhiteSpace(databaseName)) throw new ArgumentException("databaseName is required", nameof(databaseName));
+
+            ServiceBuilder.UseOwnedClient<TTimeTicker, TCronTicker>(this, connectionString, databaseName);
+            return this;
+        }
+
+        /// <summary>
+        /// Reuse an <see cref="MongoDB.Driver.IMongoClient"/> already registered in DI.
+        /// </summary>
+        public TickerQMongoOptionBuilder<TTimeTicker, TCronTicker> UseExistingMongoClient(string databaseName)
+        {
+            if (string.IsNullOrWhiteSpace(databaseName)) throw new ArgumentException("databaseName is required", nameof(databaseName));
+
+            ServiceBuilder.UseExistingClient<TTimeTicker, TCronTicker>(this, databaseName);
+            return this;
+        }
+
+        /// <summary>
+        /// Override the prefix prepended to collection names. Defaults to <c>"ticker_"</c>,
+        /// producing <c>ticker_TimeTickers</c>, <c>ticker_CronTickers</c>, <c>ticker_CronTickerOccurrences</c>.
+        /// </summary>
+        public TickerQMongoOptionBuilder<TTimeTicker, TCronTicker> SetCollectionPrefix(string prefix)
+        {
+            CollectionPrefix = prefix ?? string.Empty;
+            return this;
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/Properties/AssemblyInfo.cs
+++ b/src/TickerQ.MongoDB/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TickerQ.MongoDB.Tests")]

--- a/src/TickerQ.MongoDB/README.md
+++ b/src/TickerQ.MongoDB/README.md
@@ -1,0 +1,45 @@
+# TickerQ.MongoDB
+
+MongoDB persistence provider for [TickerQ](https://tickerq.net/). Drop-in alternative to `TickerQ.EntityFrameworkCore` — use one or the other, not both.
+
+Uses the official `MongoDB.Driver` directly. No EF Core, no ODM.
+
+## Install
+
+```bash
+dotnet add package TickerQ.MongoDB
+```
+
+## Usage
+
+```csharp
+builder.Services.AddTickerQ(options =>
+{
+    options.AddOperationalStore(mongoOptions =>
+    {
+        mongoOptions.UseTickerQMongoClient(
+            connectionString: "mongodb://localhost:27017",
+            databaseName: "tickerq");
+    });
+});
+```
+
+Or reuse an `IMongoClient` already registered in DI:
+
+```csharp
+services.AddSingleton<IMongoClient>(_ => new MongoClient("mongodb://localhost:27017"));
+
+builder.Services.AddTickerQ(options =>
+{
+    options.AddOperationalStore(mongoOptions =>
+    {
+        mongoOptions.UseExistingMongoClient(databaseName: "tickerq");
+    });
+});
+```
+
+## Notes
+
+- Concurrency uses single-document atomic `findAndModify` with an `UpdatedAt` CAS guard. No MongoDB transactions needed — works on standalone Mongo, replica sets, and Atlas free tier.
+- Indexes are created idempotently on startup, including a unique index on `(CronTickerId, ExecutionTime)` for cron occurrence deduplication.
+- Collection names default to `ticker_TimeTickers`, `ticker_CronTickers`, `ticker_CronTickerOccurrences`. Override with `SetCollectionPrefix`.

--- a/src/TickerQ.MongoDB/Serialization/TickerClassMaps.cs
+++ b/src/TickerQ.MongoDB/Serialization/TickerClassMaps.cs
@@ -1,0 +1,92 @@
+using System.Threading;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+
+namespace TickerQ.MongoDB.Serialization
+{
+    internal static class TickerClassMaps
+    {
+        private static int _registered;
+
+        public static void RegisterOnce<TTimeTicker, TCronTicker>()
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            if (Interlocked.Exchange(ref _registered, 1) != 0)
+                return;
+
+            BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+            BsonSerializer.RegisterSerializer(typeof(TickerStatus), new EnumSerializer<TickerStatus>(BsonType.Int32));
+            BsonSerializer.RegisterSerializer(typeof(RunCondition), new EnumSerializer<RunCondition>(BsonType.Int32));
+
+            RegisterTimeTicker<TTimeTicker>();
+            RegisterCronTicker<TCronTicker>();
+            RegisterCronOccurrence<TCronTicker>();
+        }
+
+        private static void RegisterTimeTicker<TTimeTicker>()
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+        {
+            // Parent/Children navigation props live on the generic intermediate
+            // TimeTickerEntity<T> — UnmapMember requires the class map ClassType to
+            // be the declaring type, so we register the intermediate first, then the concrete.
+            if (!BsonClassMap.IsClassMapRegistered(typeof(TimeTickerEntity<TTimeTicker>)))
+            {
+                BsonClassMap.RegisterClassMap<TimeTickerEntity<TTimeTicker>>
+                (cm =>
+                    {
+                        cm.AutoMap();
+                        cm.SetIgnoreExtraElements(true);
+                        cm.UnmapMember(x => x.Parent);
+                        cm.UnmapMember(x => x.Children);
+                    }
+                );
+            }
+
+            if (!BsonClassMap.IsClassMapRegistered(typeof(TTimeTicker)))
+            {
+                BsonClassMap.RegisterClassMap<TTimeTicker>
+                (cm =>
+                    {
+                        cm.AutoMap();
+                        cm.SetIgnoreExtraElements(true);
+                    }
+                );
+            }
+        }
+
+        private static void RegisterCronTicker<TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            if (BsonClassMap.IsClassMapRegistered(typeof(TCronTicker)))
+                return;
+
+            BsonClassMap.RegisterClassMap<TCronTicker>
+            (cm =>
+                {
+                    cm.AutoMap();
+                    cm.SetIgnoreExtraElements(true);
+                }
+            );
+        }
+
+        private static void RegisterCronOccurrence<TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+        {
+            if (BsonClassMap.IsClassMapRegistered(typeof(CronTickerOccurrenceEntity<TCronTicker>)))
+                return;
+
+            BsonClassMap.RegisterClassMap<CronTickerOccurrenceEntity<TCronTicker>>
+            (cm =>
+                {
+                    cm.AutoMap();
+                    cm.SetIgnoreExtraElements(true);
+                    cm.UnmapMember(x => x.CronTicker);
+                }
+            );
+        }
+    }
+}

--- a/src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
+++ b/src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<PackageId>TickerQ.MongoDB</PackageId>
+		<Authors>Arcenox; Alex Brown</Authors>
+		<Description>MongoDB persistence provider for TickerQ. Uses the official MongoDB.Driver — no EF Core, no ODM.</Description>
+		<PackageTags>$(PackageTags);mongodb;mongo</PackageTags>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="MongoDB.Driver" Version="3.5.0" />
+		<PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
+	</ItemGroup>
+</Project>

--- a/src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
+++ b/src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MongoDB.Driver" Version="3.5.0" />
+		<PackageReference Include="MongoDB.Driver" Version="3.9.0" />
 		<PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
 	</ItemGroup>
 </Project>

--- a/src/TickerQ.Utilities/Infrastructure/MappingExtensions.cs
+++ b/src/TickerQ.Utilities/Infrastructure/MappingExtensions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using TickerQ.Utilities.Entities;
+
+namespace TickerQ.Utilities.Infrastructure
+{
+    public static class MappingExtensions
+    {
+        public static Expression<Func<TCronTicker, CronTickerEntity>> ForCronTickerExpressions<TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+            => e => new CronTickerEntity
+            {
+                Id = e.Id,
+                Expression = e.Expression,
+                Function = e.Function,
+                RetryIntervals = e.RetryIntervals,
+                Retries = e.Retries,
+                IsEnabled = e.IsEnabled
+            };
+
+        public static Expression<Func<TTimeTicker, TimeTickerEntity>> ForQueueTimeTickers<TTimeTicker>()
+            where TTimeTicker : TimeTickerEntity<TTimeTicker>, new()
+            => e => new TimeTickerEntity
+            {
+                Id = e.Id,
+                Function = e.Function,
+                Retries = e.Retries,
+                RetryIntervals = e.RetryIntervals,
+                UpdatedAt = e.UpdatedAt,
+                ParentId = e.ParentId,
+                ExecutionTime = e.ExecutionTime,
+                Children = e.Children.Select(ch => new TimeTickerEntity
+                {
+                    Id = ch.Id,
+                    Function = ch.Function,
+                    Retries = ch.Retries,
+                    RetryIntervals = ch.RetryIntervals,
+                    RunCondition = ch.RunCondition,
+                    Children = ch.Children.Select(gch => new TimeTickerEntity
+                    {
+                        Function = gch.Function,
+                        Retries = gch.Retries,
+                        RetryIntervals = gch.RetryIntervals,
+                        Id = gch.Id,
+                        RunCondition = gch.RunCondition
+                    }).ToArray()
+                }).ToArray()
+            };
+
+        public static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
+            ForQueueCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
+            => e => new CronTickerOccurrenceEntity<TCronTicker>
+            {
+                Id = e.Id,
+                UpdatedAt = e.UpdatedAt,
+                CronTickerId = e.CronTickerId,
+                ExecutionTime = e.ExecutionTime,
+                CronTicker = new TCronTicker
+                {
+                    Id = e.CronTicker.Id,
+                    Function = e.CronTicker.Function,
+                    RetryIntervals = e.CronTicker.RetryIntervals,
+                    Retries = e.CronTicker.Retries
+                }
+            };
+
+        public static Expression<Func<TCronTickerOccurrence, CronTickerOccurrenceEntity<TCronTicker>>>
+            ForLatestQueuedCronTickerOccurrence<TCronTickerOccurrence, TCronTicker>()
+            where TCronTicker : CronTickerEntity, new()
+            where TCronTickerOccurrence : CronTickerOccurrenceEntity<TCronTicker>, new()
+            => e => new CronTickerOccurrenceEntity<TCronTicker>
+            {
+                Id = e.Id,
+                CreatedAt = e.CreatedAt,
+                CronTickerId = e.CronTickerId,
+                ExecutionTime = e.ExecutionTime,
+                CronTicker = new TCronTicker
+                {
+                    Id = e.CronTicker.Id,
+                    Function = e.CronTicker.Function,
+                    Expression = e.CronTicker.Expression,
+                    RetryIntervals = e.CronTicker.RetryIntervals,
+                    Retries = e.CronTicker.Retries
+                }
+            };
+    }
+}

--- a/src/TickerQ.Utilities/Properties/AssemblyInfo.cs
+++ b/src/TickerQ.Utilities/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 
 [assembly: InternalsVisibleTo("TickerQ")]
 [assembly: InternalsVisibleTo("TickerQ.EntityFrameworkCore")]
+[assembly: InternalsVisibleTo("TickerQ.MongoDB")]
 [assembly: InternalsVisibleTo("TickerQ.Dashboard")]
 [assembly: InternalsVisibleTo("TickerQ.Tests")]
 [assembly: InternalsVisibleTo("TickerQ.SDK")]

--- a/src/TickerQ.Utilities/Properties/AssemblyInfo.cs
+++ b/src/TickerQ.Utilities/Properties/AssemblyInfo.cs
@@ -11,5 +11,6 @@
 [assembly: InternalsVisibleTo("TickerQ.Caching.StackExchangeRedis")]
 [assembly: InternalsVisibleTo("TickerQ.EntityFrameworkCore.Tests")]
 [assembly: InternalsVisibleTo("TickerQ.Caching.StackExchangeRedis.Tests")]
+[assembly: InternalsVisibleTo("TickerQ.MongoDB.Tests")]
 // To be testable using NSubsitute
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/tests/TickerQ.MongoDB.Tests/MongoPersistenceProviderTests.cs
+++ b/tests/TickerQ.MongoDB.Tests/MongoPersistenceProviderTests.cs
@@ -1,0 +1,242 @@
+using MongoDB.Driver;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Models;
+
+namespace TickerQ.MongoDB.Tests;
+
+[Collection("Mongo")]
+public class MongoPersistenceProviderTests : IClassFixture<MongoTestFixture>, IAsyncLifetime
+{
+    private readonly MongoTestFixture _f;
+
+    public MongoPersistenceProviderTests(MongoTestFixture fixture) => _f = fixture;
+
+    public Task InitializeAsync() => _f.DropAllAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private TimeTickerEntity NewTimeTicker(DateTime? executionTime = null, TickerStatus status = TickerStatus.Idle)
+    {
+        var t = new TimeTickerEntity
+        {
+            Id = Guid.NewGuid(),
+            Function = "test-fn",
+            Request = Array.Empty<byte>(),
+            ExecutionTime = executionTime ?? _f.FixedNow.AddSeconds(1)
+        };
+        typeof(TimeTickerEntity).GetProperty(nameof(t.Status))!.SetValue(t, status);
+        typeof(TimeTickerEntity).GetProperty(nameof(t.CreatedAt))!.SetValue(t, _f.FixedNow);
+        typeof(TimeTickerEntity).GetProperty(nameof(t.UpdatedAt))!.SetValue(t, _f.FixedNow);
+        return t;
+    }
+
+    private CronTickerEntity NewCron(string function = "cron-fn", string expression = "* * * * *")
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Function = function,
+            Expression = expression,
+            Request = Array.Empty<byte>(),
+            IsEnabled = true
+        };
+
+    [Fact]
+    public async Task InsertAndGetTimeTicker_RoundTrips()
+    {
+        var ticker = NewTimeTicker();
+        await _f.Provider.AddTimeTickers([ticker], CancellationToken.None);
+
+        var fetched = await _f.Provider.GetTimeTickerById(ticker.Id, CancellationToken.None);
+        Assert.NotNull(fetched);
+        Assert.Equal(ticker.Function, fetched!.Function);
+        Assert.Equal(TickerStatus.Idle, fetched.Status);
+    }
+
+    [Fact]
+    public async Task GetEarliestTimeTickers_ReturnsIdleWithinOneSecond()
+    {
+        var ticker = NewTimeTicker(executionTime: _f.FixedNow.AddMilliseconds(500));
+        await _f.Provider.AddTimeTickers([ticker], CancellationToken.None);
+
+        var earliest = await _f.Provider.GetEarliestTimeTickers(CancellationToken.None);
+        Assert.Single(earliest);
+        Assert.Equal(ticker.Id, earliest[0].Id);
+    }
+
+    [Fact]
+    public async Task GetEarliestTimeTickers_SkipsStaleRows()
+    {
+        var stale = NewTimeTicker(executionTime: _f.FixedNow.AddSeconds(-5));
+        await _f.Provider.AddTimeTickers([stale], CancellationToken.None);
+
+        var earliest = await _f.Provider.GetEarliestTimeTickers(CancellationToken.None);
+        Assert.Empty(earliest);
+    }
+
+    [Fact]
+    public async Task QueueTimeTickers_AcquiresLockOnce_RejectsStaleUpdatedAt()
+    {
+        var ticker = NewTimeTicker();
+        await _f.Provider.AddTimeTickers([ticker], CancellationToken.None);
+
+        var fresh = await _f.Provider.GetTimeTickerById(ticker.Id, CancellationToken.None);
+        Assert.NotNull(fresh);
+
+        var queued1 = new List<TimeTickerEntity>();
+        await foreach (var t in _f.Provider.QueueTimeTickers([new TimeTickerEntity { Id = fresh!.Id, UpdatedAt = fresh.UpdatedAt }], CancellationToken.None))
+            queued1.Add(t);
+        Assert.Single(queued1);
+
+        // Second attempt with the old UpdatedAt should win nothing — CAS fails.
+        var queued2 = new List<TimeTickerEntity>();
+        await foreach (var t in _f.Provider.QueueTimeTickers([new TimeTickerEntity { Id = fresh.Id, UpdatedAt = fresh.UpdatedAt }], CancellationToken.None))
+            queued2.Add(t);
+        Assert.Empty(queued2);
+    }
+
+    [Fact]
+    public async Task ReleaseAcquiredTimeTickers_ClearsLockAndResetsStatus()
+    {
+        var ticker = NewTimeTicker();
+        await _f.Provider.AddTimeTickers([ticker], CancellationToken.None);
+
+        var fresh = await _f.Provider.GetTimeTickerById(ticker.Id, CancellationToken.None);
+        await foreach (var _ in _f.Provider.QueueTimeTickers([new TimeTickerEntity { Id = fresh!.Id, UpdatedAt = fresh.UpdatedAt }], CancellationToken.None)) { }
+
+        await _f.Provider.ReleaseAcquiredTimeTickers([ticker.Id], CancellationToken.None);
+
+        var after = await _f.Provider.GetTimeTickerById(ticker.Id, CancellationToken.None);
+        Assert.Equal(TickerStatus.Idle, after!.Status);
+        Assert.Null(after.LockHolder);
+        Assert.Null(after.LockedAt);
+    }
+
+    [Fact]
+    public async Task UpdateTimeTicker_AppliesStatusAndElapsedTime()
+    {
+        var ticker = NewTimeTicker();
+        await _f.Provider.AddTimeTickers([ticker], CancellationToken.None);
+
+        var ctx = new InternalFunctionContext
+        {
+            TickerId = ticker.Id,
+            FunctionName = "test-fn",
+            Type = TickerType.TimeTicker,
+            ExecutedAt = _f.FixedNow,
+        }
+        .SetProperty(c => c.Status, TickerStatus.Done)
+        .SetProperty(c => c.ExecutedAt, _f.FixedNow)
+        .SetProperty(c => c.ElapsedTime, 123L)
+        .SetProperty(c => c.ReleaseLock, true);
+
+        var modified = await _f.Provider.UpdateTimeTicker(ctx, CancellationToken.None);
+        Assert.Equal(1, modified);
+
+        var after = await _f.Provider.GetTimeTickerById(ticker.Id, CancellationToken.None);
+        Assert.Equal(TickerStatus.Done, after!.Status);
+        Assert.Equal(123L, after.ElapsedTime);
+        Assert.Null(after.LockHolder);
+    }
+
+    [Fact]
+    public async Task ReleaseDeadNodeTimeTickerResources_ClearsLocksForThatNode()
+    {
+        var ticker = NewTimeTicker();
+        await _f.Provider.AddTimeTickers([ticker], CancellationToken.None);
+
+        // Force-lock under another node id by direct write to simulate a dead node.
+        await _f.TimeTickers.UpdateOneAsync(
+            Builders<TimeTickerEntity>.Filter.Eq(x => x.Id, ticker.Id),
+            Builders<TimeTickerEntity>.Update
+                .Set(x => x.LockHolder, "dead-node")
+                .Set(x => x.LockedAt, _f.FixedNow)
+                .Set(x => x.Status, TickerStatus.Queued));
+
+        await _f.Provider.ReleaseDeadNodeTimeTickerResources("dead-node", CancellationToken.None);
+
+        var after = await _f.Provider.GetTimeTickerById(ticker.Id, CancellationToken.None);
+        Assert.Equal(TickerStatus.Idle, after!.Status);
+        Assert.Null(after.LockHolder);
+    }
+
+    [Fact]
+    public async Task InsertCronTickerOccurrences_UniqueIndexBlocksDuplicateSlots()
+    {
+        var cron = NewCron();
+        await _f.Provider.InsertCronTickers([cron], CancellationToken.None);
+
+        var execTime = _f.FixedNow.AddSeconds(5);
+        var occ1 = new CronTickerOccurrenceEntity<CronTickerEntity>
+        {
+            Id = Guid.NewGuid(),
+            CronTickerId = cron.Id,
+            ExecutionTime = execTime,
+            Status = TickerStatus.Queued,
+            CreatedAt = _f.FixedNow,
+            UpdatedAt = _f.FixedNow
+        };
+        var occ2 = new CronTickerOccurrenceEntity<CronTickerEntity>
+        {
+            Id = Guid.NewGuid(),
+            CronTickerId = cron.Id,
+            ExecutionTime = execTime,
+            Status = TickerStatus.Queued,
+            CreatedAt = _f.FixedNow,
+            UpdatedAt = _f.FixedNow
+        };
+
+        var inserted = await _f.Provider.InsertCronTickerOccurrences([occ1, occ2], CancellationToken.None);
+        Assert.Equal(1, inserted);
+    }
+
+    [Fact]
+    public async Task SkipStaleCronOccurrences_MarksOldRowsAsSkipped()
+    {
+        var cron = NewCron();
+        await _f.Provider.InsertCronTickers([cron], CancellationToken.None);
+
+        var occ = new CronTickerOccurrenceEntity<CronTickerEntity>
+        {
+            Id = Guid.NewGuid(),
+            CronTickerId = cron.Id,
+            ExecutionTime = _f.FixedNow.AddSeconds(-60),
+            Status = TickerStatus.Idle,
+            CreatedAt = _f.FixedNow.AddSeconds(-120),
+            UpdatedAt = _f.FixedNow.AddSeconds(-120)
+        };
+        await _f.Provider.InsertCronTickerOccurrences([occ], CancellationToken.None);
+
+        var skipped = await _f.Provider.SkipStaleCronOccurrencesAsync(TimeSpan.FromSeconds(5), CancellationToken.None);
+        Assert.Equal(1, skipped);
+
+        var after = await _f.CronTickerOccurrences
+            .Find(Builders<CronTickerOccurrenceEntity<CronTickerEntity>>.Filter.Eq(x => x.Id, occ.Id))
+            .FirstOrDefaultAsync();
+        Assert.Equal(TickerStatus.Skipped, after.Status);
+    }
+
+    [Fact]
+    public async Task IndexProvisioner_IsIdempotent_OnRepeatedCalls()
+    {
+        // Fixture already ran StartAsync once. Run again — should not throw.
+        var provisioner = _f.NewProvisioner();
+        await provisioner.StartAsync(CancellationToken.None);
+        await provisioner.StartAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task GetAllCronTickerExpressions_ExcludesDisabledAndPaused()
+    {
+        var enabled = NewCron("enabled-fn");
+        var disabled = NewCron("disabled-fn");
+        disabled.IsEnabled = false;
+        var paused = NewCron("paused-fn");
+        paused.IsSystemPaused = true;
+
+        await _f.Provider.InsertCronTickers([enabled, disabled, paused], CancellationToken.None);
+
+        var result = await _f.Provider.GetAllCronTickerExpressions(CancellationToken.None);
+        Assert.Single(result);
+        Assert.Equal("enabled-fn", result[0].Function);
+    }
+}

--- a/tests/TickerQ.MongoDB.Tests/MongoTestFixture.cs
+++ b/tests/TickerQ.MongoDB.Tests/MongoTestFixture.cs
@@ -1,0 +1,70 @@
+using MongoDB.Driver;
+using NSubstitute;
+using Testcontainers.MongoDb;
+using TickerQ.MongoDB.Indexes;
+using TickerQ.MongoDB.Infrastructure;
+using TickerQ.MongoDB.Serialization;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Entities;
+using TickerQ.Utilities.Interfaces;
+
+namespace TickerQ.MongoDB.Tests;
+
+/// <summary>
+/// Shared MongoDB container for the whole test class — spinning a container per test is too slow.
+/// Each test should call <see cref="DropAllAsync"/> in its setup to start from a clean DB.
+/// </summary>
+public class MongoTestFixture : IAsyncLifetime
+{
+    public MongoDbContainer Container { get; } = new MongoDbBuilder()
+        .WithImage("mongo:7")
+        .Build();
+
+    public IMongoClient Client { get; private set; } = null!;
+    public IMongoDatabase Database { get; private set; } = null!;
+    public IMongoCollection<TimeTickerEntity> TimeTickers => _context.TimeTickers;
+    public IMongoCollection<CronTickerEntity> CronTickers => _context.CronTickers;
+    public IMongoCollection<CronTickerOccurrenceEntity<CronTickerEntity>> CronTickerOccurrences => _context.CronTickerOccurrences;
+    public ITickerPersistenceProvider<TimeTickerEntity, CronTickerEntity> Provider { get; private set; } = null!;
+    public ITickerClock Clock { get; private set; } = null!;
+    public DateTime FixedNow { get; } = new(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+    public const string NodeId = "test-node-1";
+
+    private ITickerMongoContext<TimeTickerEntity, CronTickerEntity> _context = null!;
+
+    public async Task InitializeAsync()
+    {
+        await Container.StartAsync();
+
+        TickerClassMaps.RegisterOnce<TimeTickerEntity, CronTickerEntity>();
+
+        Client = new MongoClient(Container.GetConnectionString());
+        Database = Client.GetDatabase("tickerq_test");
+        _context = new TickerMongoContext<TimeTickerEntity, CronTickerEntity>(Database, "ticker_");
+
+        Clock = Substitute.For<ITickerClock>();
+        Clock.UtcNow.Returns(FixedNow);
+
+        var options = new SchedulerOptionsBuilder { NodeIdentifier = NodeId };
+        Provider = new TickerMongoPersistenceProvider<TimeTickerEntity, CronTickerEntity>(_context, Clock, options);
+
+        var provisioner = new TickerIndexProvisioner<TimeTickerEntity, CronTickerEntity>(_context);
+        await provisioner.StartAsync(CancellationToken.None);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Container.DisposeAsync();
+    }
+
+    public async Task DropAllAsync()
+    {
+        await TimeTickers.DeleteManyAsync(Builders<TimeTickerEntity>.Filter.Empty);
+        await CronTickers.DeleteManyAsync(Builders<CronTickerEntity>.Filter.Empty);
+        await CronTickerOccurrences.DeleteManyAsync(Builders<CronTickerOccurrenceEntity<CronTickerEntity>>.Filter.Empty);
+    }
+
+    /// <summary>Internal helper to instantiate a fresh provisioner for idempotency tests.</summary>
+    internal TickerIndexProvisioner<TimeTickerEntity, CronTickerEntity> NewProvisioner()
+        => new(_context);
+}

--- a/tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj
+++ b/tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TickerQ\TickerQ.csproj" />
+    <ProjectReference Include="..\..\src\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+    <ProjectReference Include="..\..\src\TickerQ.MongoDB\TickerQ.MongoDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj
+++ b/tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="4.8.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>


### PR DESCRIPTION
Supersedes #868. Combines the Utilities "open up" changes from that PR with the MongoDB provider itself into one PR. The provider lives here under `src/` alongside the other packages, not in a separate repo.

## 1. Open up TickerQ.Utilities for third-party providers (was #868)

- Move the pure entity-projection helpers (`ForCronTickerExpressions`, `ForQueueTimeTickers`, `ForQueueCronTickerOccurrence`, `ForLatestQueuedCronTickerOccurrence`) from EF to `src/TickerQ.Utilities/Infrastructure/MappingExtensions.cs` (public), so any provider can reuse them. They have no EF Core dependency. The EF-specific `SetPropertyCalls` helpers stay in EF; their class is renamed `MappingExtensions` to `EfUpdateExtensions` to avoid a name clash (both internal).
- Grant `InternalsVisibleTo` to `TickerQ.MongoDB` and `TickerQ.MongoDB.Tests`, mirroring the existing EF grants, so a non-EF provider can write internal audit fields (Status, LockHolder, LockedAt, UpdatedAt, ...).

## 2. MongoDB persistence provider

- `src/TickerQ.MongoDB`: `ITickerPersistenceProvider` over the official `MongoDB.Driver` (no EF Core, no ODM). DI extensions, index provisioning, serialization class maps, options builder.
- `tests/TickerQ.MongoDB.Tests`: provider tests using `Testcontainers.MongoDb` (needs Docker on the runner).
- `samples/TickerQ.Sample.MongoDB`: minimal usage sample.
- Package metadata: `<Authors>Arcenox; Alex Brown</Authors>`, `PackageId=TickerQ.MongoDB`. Publishing under the Arcenox NuGet account is handled by the existing release pipeline.
- CI: wired into `pr.yaml` (build + test) and `build.yml` (restore + build + pack + nuget-existence check), mirroring the EF provider.

Follows the repo convention of `PackageReference TickerQ.Utilities Version=$(Version)`. Verified locally: EF and the MongoDB provider + test project build clean against a freshly packed Utilities.