### PR TITLE
Allow external persistence providers to materialize ticker entities

### DIFF
--- a/src/TickerQ.Utilities/Entities/BaseEntity/BaseTickerEntity.cs
+++ b/src/TickerQ.Utilities/Entities/BaseEntity/BaseTickerEntity.cs
@@ -9,10 +9,10 @@ namespace TickerQ.Utilities.Entities.BaseEntity
         public virtual string Function { get; set; }
         public virtual string Description { get; set; }
         [JsonInclude]
-        public virtual string InitIdentifier { get; internal set; }
+        public virtual string InitIdentifier { get; protected internal set; }
         [JsonInclude]
-        public virtual DateTime CreatedAt { get; internal set; } = DateTime.UtcNow;
+        public virtual DateTime CreatedAt { get; protected internal set; } = DateTime.UtcNow;
         [JsonInclude]
-        public virtual DateTime UpdatedAt { get; internal set; } = DateTime.UtcNow;
+        public virtual DateTime UpdatedAt { get; protected internal set; } = DateTime.UtcNow;
     }
 }

--- a/src/TickerQ.Utilities/Entities/TimeTickerEntity.cs
+++ b/src/TickerQ.Utilities/Entities/TimeTickerEntity.cs
@@ -12,29 +12,29 @@ namespace TickerQ.Utilities.Entities
     public class TimeTickerEntity<TTicker> : BaseTickerEntity where TTicker : TimeTickerEntity<TTicker>
     {
         [JsonInclude]
-        public virtual TickerStatus Status { get; internal set; }
+        public virtual TickerStatus Status { get; protected internal set; }
         [JsonInclude]
-        public virtual string LockHolder { get; internal set; }
+        public virtual string LockHolder { get; protected internal set; }
         public virtual byte[] Request { get; set; }
         public virtual DateTime? ExecutionTime { get; set; }
         [JsonInclude]
-        public virtual DateTime? LockedAt { get; internal set; }
+        public virtual DateTime? LockedAt { get; protected internal set; }
         [JsonInclude]
-        public virtual DateTime? ExecutedAt { get; internal set; }
+        public virtual DateTime? ExecutedAt { get; protected internal set; }
         [JsonInclude]
-        public virtual string ExceptionMessage { get; internal set; }
+        public virtual string ExceptionMessage { get; protected internal set; }
         [JsonInclude]
-        public virtual string SkippedReason { get; internal set; }
+        public virtual string SkippedReason { get; protected internal set; }
         [JsonInclude]
-        public virtual long ElapsedTime { get; internal set; }
+        public virtual long ElapsedTime { get; protected internal set; }
         public virtual int Retries { get; set; }
         [JsonInclude]
-        public virtual int RetryCount { get; internal set; }
+        public virtual int RetryCount { get; protected internal set; }
         public virtual int[] RetryIntervals { get; set; }
         [JsonInclude]
-        public virtual Guid? ParentId { get; internal set; }
+        public virtual Guid? ParentId { get; protected internal set; }
         [JsonIgnore]
-        public virtual TTicker Parent { get; internal set; }
+        public virtual TTicker Parent { get; protected internal set; }
         public virtual ICollection<TTicker> Children { get; set; } = new List<TTicker>();
         public virtual RunCondition? RunCondition { get; set; }
     }


### PR DESCRIPTION
## Summary

Change persistence-managed entity setters from `internal` to `protected internal` on:

- `BaseTickerEntity`
- `TimeTickerEntity<TTicker>`

## Motivation

TickerQ exposes `ITickerPersistenceProvider<TTimeTicker, TCronTicker>` for custom persistence implementations, but an implementation in a separate assembly cannot hydrate persistence-managed state such as status, lock ownership, timestamps, retry count, and parent relationships.

The current alternatives are provider-specific `InternalsVisibleTo` declarations or runtime access workarounds such as reflection and `UnsafeAccessor`. The latter are particularly undesirable for Native AOT consumers.

`protected internal` preserves all existing in-assembly access while allowing an external provider to use derived ticker entity types with an AOT-safe materialization path. The setters remain unavailable to ordinary public callers, so this does not turn persistence-managed state into generally mutable API.

## Impact

- No runtime behavior changes.
- No serialization contract changes.
- Existing internal callers retain access.
- External persistence providers can hydrate derived entity types without assembly-specific friend declarations or runtime accessor hacks.

## Validation

- `TickerQ.Utilities` Release build: passed with 0 warnings and 0 errors.
- An external `net10.0` project without `InternalsVisibleTo`, deriving from `TimeTickerEntity<TTicker>` and assigning every changed property: passed with 0 warnings and 0 errors.
- Reproduced the repository PR workflow's local `TickerQ.Utilities` package bootstrap; the full `TickerQ.slnx` Release build completed with 0 errors.
- Tests passed: core 563/563, Entity Framework Core 74/74, StackExchangeRedis 96/96, MongoDB 11/11. Two unrelated core tests were flaky under the full parallel run and passed immediately when rerun in isolation.
