### PR TITLE
Simplify the project structure and the build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,62 +83,14 @@ jobs:
         run: npm run build
         working-directory: src/TickerQ.Dashboard/wwwroot
 
-      - name: Build TickerQ.Utilities
-        run: dotnet build src/TickerQ.Utilities/TickerQ.Utilities.csproj --configuration Release
-
-      - name: Pack TickerQ.Utilities
-        run: dotnet pack src/TickerQ.Utilities/TickerQ.Utilities.csproj --configuration Release --output ./nupkgs
-
-      - name: Add local nupkgs source
-        run: dotnet nuget add source "$(pwd)/nupkgs" --name LocalNupkgs
-
-      - name: Restore packages with local source
-        run: |
-          dotnet restore src/TickerQ/TickerQ.csproj
-          dotnet restore src/TickerQ.EntityFrameworkCore/TickerQ.EntityFrameworkCore.csproj
-          dotnet restore src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
-          dotnet restore src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj
-          dotnet restore src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj
-          dotnet restore src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
-          dotnet restore hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj
-          dotnet restore hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
-          dotnet restore tests/TickerQ.Tests/TickerQ.Tests.csproj
-          dotnet restore tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj
-          dotnet restore tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj
-
-      - name: Build TickerQ.SourceGenerator
-        run: dotnet build src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj --configuration Release
-
-      - name: Build other projects
-        run: |
-          dotnet build src/TickerQ/TickerQ.csproj --configuration Release
-          dotnet build src/TickerQ.EntityFrameworkCore/TickerQ.EntityFrameworkCore.csproj --configuration Release
-          dotnet build src/TickerQ.Dashboard/TickerQ.Dashboard.csproj --configuration Release
-          dotnet build src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj --configuration Release
-          dotnet build src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj --configuration Release
-          dotnet build src/TickerQ.MongoDB/TickerQ.MongoDB.csproj --configuration Release
-          dotnet build hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj --configuration Release
-          dotnet build hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj --configuration Release
-          dotnet build tests/TickerQ.Tests/TickerQ.Tests.csproj --configuration Release
-          dotnet build tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj --configuration Release
-          dotnet build tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj --configuration Release
+      - name: Build solution
+        run: dotnet build TickerQ.slnx --configuration Release
 
       - name: Run tests
-        run: |
-          dotnet test tests/TickerQ.Tests/ --configuration Release --no-build
-          dotnet test tests/TickerQ.EntityFrameworkCore.Tests/ --configuration Release --no-build
-          dotnet test tests/TickerQ.Caching.StackExchangeRedis.Tests/ --configuration Release --no-build
+        run: dotnet test TickerQ.slnx --configuration Release --no-build
 
-      - name: Pack other projects
-        run: |
-          dotnet pack src/TickerQ/TickerQ.csproj --configuration Release --output ./nupkgs
-          dotnet pack src/TickerQ.EntityFrameworkCore/TickerQ.EntityFrameworkCore.csproj --configuration Release --output ./nupkgs
-          dotnet pack src/TickerQ.Dashboard/TickerQ.Dashboard.csproj --configuration Release --output ./nupkgs
-          dotnet pack src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj --configuration Release --output ./nupkgs
-          dotnet pack src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj --configuration Release --output ./nupkgs
-          dotnet pack src/TickerQ.MongoDB/TickerQ.MongoDB.csproj --configuration Release --output ./nupkgs
-          dotnet pack hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj --configuration Release --output ./nupkgs
-          dotnet pack hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj --configuration Release --output ./nupkgs
+      - name: Create NuGet packages
+        run: dotnet pack TickerQ.slnx --configuration Release --no-build --output ./nupkgs
 
       - name: Show package file sizes
         run: |

--- a/TickerQ.slnx
+++ b/TickerQ.slnx
@@ -13,9 +13,11 @@
     <File Path=".github/workflows/publish.yml" />
   </Folder>
   <Folder Name="/benchmarks/">
+    <File Path="benchmarks/Directory.Build.props" />
     <Project Path="benchmarks/TickerQ.Benchmarks/TickerQ.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/samples/">
+    <File Path="samples/Directory.Build.props" />
     <Project Path="samples/TickerQ.Sample.ApplicationDbContext/TickerQ.Sample.ApplicationDbContext.csproj" />
     <Project Path="samples/TickerQ.Sample.Console/TickerQ.Sample.Console.csproj" />
     <Project Path="samples/TickerQ.Sample.MongoDB/TickerQ.Sample.MongoDB.csproj" />
@@ -39,6 +41,7 @@
     <Project Path="hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <File Path="tests/Directory.Build.props" />
     <Project Path="tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj" />
     <Project Path="tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj" />
     <Project Path="tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj" />

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -4,7 +4,6 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
 
 </Project>

--- a/benchmarks/TickerQ.Benchmarks/TickerQ.Benchmarks.csproj
+++ b/benchmarks/TickerQ.Benchmarks/TickerQ.Benchmarks.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/hub/Directory.Build.props
+++ b/hub/Directory.Build.props
@@ -1,6 +1,10 @@
 <Project>
     <Import Project="../src/Directory.Build.props" />
 
+    <PropertyGroup>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+
     <!-- Override icon path: src/Directory.Build.props uses ../../icon.jpg relative to project,
          which is wrong for hub/ projects. Use absolute path based on this file's location. -->
     <ItemGroup>

--- a/hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
+++ b/hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <IsPackable>true</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>TickerQ.RemoteExecutor</PackageId>

--- a/hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
+++ b/hub/remoteExecutor/TickerQ.RemoteExecutor/TickerQ.RemoteExecutor.csproj
@@ -12,7 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
+    <ProjectReference Include="..\..\..\src\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />

--- a/hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj
+++ b/hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <IsPackable>true</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>TickerQ.SDK</AssemblyName>
     <PackageId>TickerQ.SDK</PackageId>

--- a/hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj
+++ b/hub/sdks/dotnet/TickerQ.SDK/TickerQ.SDK.csproj
@@ -12,7 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
+    <ProjectReference Include="..\..\..\..\src\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,6 @@
         <Copyright>Copyright 2025-present Arcenox LLC</Copyright>
         <PackageTags>ticker;queue;cron;time;scheduler;fire-and-forget</PackageTags>
         <PackageIcon>icon.jpg</PackageIcon>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>default</LangVersion>
 
         <!-- Source Link -->

--- a/src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj
+++ b/src/TickerQ.Caching.StackExchangeRedis/TickerQ.Caching.StackExchangeRedis.csproj
@@ -14,7 +14,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(DotNetVersion)" />
-      <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
     </ItemGroup>
 </Project>

--- a/src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
+++ b/src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
@@ -24,7 +24,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
+        <ProjectReference Include="..\TickerQ.Utilities\TickerQ.Utilities.csproj" />
     </ItemGroup>
 
     <!-- Prevent static web asset discovery -->

--- a/src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
+++ b/src/TickerQ.Dashboard/TickerQ.Dashboard.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <IsPackable>true</IsPackable>
         <DisableStaticWebAssets>true</DisableStaticWebAssets>
         <PackageId>TickerQ.Dashboard</PackageId>
         <Description>Dashboard UI for visualizing and monitoring TickerQ scheduled jobs.</Description>

--- a/src/TickerQ.EntityFrameworkCore/TickerQ.EntityFrameworkCore.csproj
+++ b/src/TickerQ.EntityFrameworkCore/TickerQ.EntityFrameworkCore.csproj
@@ -12,8 +12,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="FlexLabs.EntityFrameworkCore.Upsert" Version="$(DotNetVersion)" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(DotNetVersion)" />
-		<PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
 	</ItemGroup>
 </Project>

--- a/src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj
+++ b/src/TickerQ.Instrumentation.OpenTelemetry/TickerQ.Instrumentation.OpenTelemetry.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="[1.15.3,)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="[1.15.3,)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(DotNetAbstractionsVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
   </ItemGroup>
 </Project>

--- a/src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
+++ b/src/TickerQ.MongoDB/TickerQ.MongoDB.csproj
@@ -13,7 +13,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\TickerQ.Utilities\TickerQ.Utilities.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="MongoDB.Driver" Version="3.9.0" />
-		<PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
 	</ItemGroup>
 </Project>

--- a/src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj
+++ b/src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj
@@ -4,7 +4,6 @@
         <LangVersion>8.0</LangVersion>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <AssemblyName>TickerQ.SourceGenerator</AssemblyName>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/TickerQ/TickerQ.csproj
+++ b/src/TickerQ/TickerQ.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
    <ItemGroup>
-       <PackageReference Include="TickerQ.Utilities" Version="$(Version)" />
+       <ProjectReference Include="..\TickerQ.Utilities\TickerQ.Utilities.csproj" />
    </ItemGroup>
 
     <Target Name="CopyAnalyzer" AfterTargets="Build">

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,7 +4,6 @@
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <DotNetAbstractionsVersion>[8.0.0,)</DotNetAbstractionsVersion>
     </PropertyGroup>
 

--- a/tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj
+++ b/tests/TickerQ.Caching.StackExchangeRedis.Tests/TickerQ.Caching.StackExchangeRedis.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj
+++ b/tests/TickerQ.EntityFrameworkCore.Tests/TickerQ.EntityFrameworkCore.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj
+++ b/tests/TickerQ.MongoDB.Tests/TickerQ.MongoDB.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TickerQ.SourceGenerator.Tests/TickerQ.SourceGenerator.Tests.csproj
+++ b/tests/TickerQ.SourceGenerator.Tests/TickerQ.SourceGenerator.Tests.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/TickerQ.Tests/TickerQ.Tests.csproj
+++ b/tests/TickerQ.Tests/TickerQ.Tests.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Currently, as of 3acd0f314a351817a3159d7d29a3798c8612a263, the TickerQ solution does not build, see https://github.com/Arcenox-co/TickerQ/pull/874#issuecomment-5458835026

This pull request improves the TickerQ build, both locally and on GitHub actions.

Before this pull, the build required to build the `TickerQ.Utilities` project separately and installing its package in a local NuGet source. This prevents someone to just checkout the repository and build the solution. This was discussed in #874.

After this pull request, the references to `TickerQ.Utilities` are `ProjectReference` instead of `PackageReference` elements for a smooth build experience. Note that `dotnet pack` automatically turns project references into package references.

Also, the _Build NuGet Packages_ action was largely simplified. Building, testing and creating the NuGet packages is now 3 lines:

* `dotnet build TickerQ.slnx --configuration Release`
* `dotnet test TickerQ.slnx --configuration Release --no-build`
* `dotnet pack TickerQ.slnx --configuration Release --no-build --output ./nupkgs`

All the project dependencies are handled automatically, no need for specific build order. This is basically the same process as when a user clones the repository, opens the solution in their IDE and builds the solution.

Also, some MSBuild properties have been simplified and moved into the appropriate `Directory.Build.props` files to avoid duplication. `GeneratePackageOnBuild` has been removed since it can slow down the build and the GitHub actions scripts takes care of explicitly creating the NuGet packages.