### PR TITLE
Propagate cancellation while loading typed ticker requests

### DIFF
--- a/src/TickerQ.Utilities/TickerFunctionProvider.cs
+++ b/src/TickerQ.Utilities/TickerFunctionProvider.cs
@@ -376,6 +376,10 @@ namespace TickerQ.Utilities
                 var internalTickerManager = context.ServiceScope.ServiceProvider.GetService<IInternalTickerManager>();
                 return await internalTickerManager.GetRequestAsync<T>(context.Id, context.Type, cancellationToken);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 var logger = context.ServiceScope.ServiceProvider.GetService<ITickerQInstrumentation>();
@@ -398,6 +402,10 @@ namespace TickerQ.Utilities
             {
                 var internalTickerManager = context.ServiceScope.ServiceProvider.GetService<IInternalTickerManager>();
                 return await internalTickerManager.GetRequestAsync(context.Id, context.Type, typeInfo, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/tests/TickerQ.Tests/TickerRequestProviderTests.cs
+++ b/tests/TickerQ.Tests/TickerRequestProviderTests.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using TickerQ.Utilities;
+using TickerQ.Utilities.Base;
+using TickerQ.Utilities.Enums;
+using TickerQ.Utilities.Interfaces.Managers;
+
+namespace TickerQ.Tests;
+
+public class TickerRequestProviderTests
+{
+    [Fact]
+    public async Task GetRequestAsync_WhenPersistenceIsCancelled_PropagatesCancellation()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+        var cancellationToken = cancellationSource.Token;
+        var manager = Substitute.For<IInternalTickerManager>();
+        manager
+            .GetRequestAsync<Request>(Arg.Any<Guid>(), Arg.Any<TickerType>(), cancellationToken)
+            .Returns(Task.FromCanceled<Request>(cancellationToken));
+        await using var provider = CreateServiceProvider(manager);
+        await using var scope = provider.CreateAsyncScope();
+        var context = CreateContext(scope);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => TickerRequestProvider.GetRequestAsync<Request>(context, cancellationToken));
+    }
+
+    [Fact]
+    public async Task GetRequestAsync_WithJsonTypeInfo_WhenPersistenceIsCancelled_PropagatesCancellation()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+        var cancellationToken = cancellationSource.Token;
+        var typeInfo = (System.Text.Json.Serialization.Metadata.JsonTypeInfo<Request>)
+            JsonSerializerOptions.Default.GetTypeInfo(typeof(Request));
+        var manager = Substitute.For<IInternalTickerManager>();
+        manager
+            .GetRequestAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<TickerType>(),
+                typeInfo,
+                cancellationToken)
+            .Returns(Task.FromCanceled<Request>(cancellationToken));
+        await using var provider = CreateServiceProvider(manager);
+        await using var scope = provider.CreateAsyncScope();
+        var context = CreateContext(scope);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => TickerRequestProvider.GetRequestAsync(
+                context,
+                typeInfo,
+                cancellationToken));
+    }
+
+    private static ServiceProvider CreateServiceProvider(IInternalTickerManager manager)
+    {
+        return new ServiceCollection()
+            .AddSingleton(manager)
+            .BuildServiceProvider();
+    }
+
+    private static TickerFunctionContext CreateContext(AsyncServiceScope scope)
+    {
+        var context = new TickerFunctionContext();
+        context.SetServiceScope(scope);
+        return context;
+    }
+
+    private sealed record Request(string Value);
+}


### PR DESCRIPTION
## Summary

- preserve caller cancellation while loading typed ticker request payloads
- avoid converting cancellation into a null/default request
- cover both reflection-based and `JsonTypeInfo` request-loading overloads

## Problem

`TickerRequestProvider.GetRequestAsync` currently catches `OperationCanceledException`, records it as a deserialization failure, and returns `default`. Interface-based typed jobs are then invoked with a null request, obscuring cancellation behind a later `NullReferenceException`.

## Testing

- `dotnet build src/TickerQ.SourceGenerator/TickerQ.SourceGenerator.csproj`
- `dotnet test tests/TickerQ.Tests/TickerQ.Tests.csproj --filter FullyQualifiedName~TickerRequestProviderTests --no-restore --verbosity minimal`
